### PR TITLE
[vm] check captured value depth when packing closures

### DIFF
--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -2455,6 +2455,7 @@ impl Frame {
                             )?;
                         }
                         let captured = interpreter.operand_stack.popn(mask.captured_count())?;
+                        check_captured_value_depths(interpreter.vm_config, &captured)?;
                         let lazy_function = LazyLoadedFunction::new_resolved(
                             interpreter.layout_converter,
                             gas_meter,
@@ -2499,6 +2500,7 @@ impl Frame {
                             )?;
                         }
                         let captured = interpreter.operand_stack.popn(mask.captured_count())?;
+                        check_captured_value_depths(interpreter.vm_config, &captured)?;
                         let lazy_function = LazyLoadedFunction::new_resolved(
                             interpreter.layout_converter,
                             gas_meter,
@@ -2970,4 +2972,22 @@ impl Frame {
         ));
         err.with_sub_status(EPARANOID_FAILURE)
     }
+}
+
+/// Checks that the values captured by a newly packed closure do not exceed the configured
+/// maximum value depth. Each captured value is counted from depth 1 (the closure wrapper does
+/// not add a level), so the boundary matches the copy checks that run when captures are copied.
+/// As a consequence, a closure packed at the limit is one level deeper than the maximum when
+/// counted from its own root, and copying, comparing, or storing it fails; this transient
+/// overshoot is inherent (struct packing over a max-depth closure field creates it too, since
+/// `Pack` only checks type depth) and matches upstream behavior.
+fn check_captured_value_depths(vm_config: &VMConfig, captured: &[Value]) -> PartialVMResult<()> {
+    if vm_config.enable_depth_checks {
+        if let Some(max_depth) = vm_config.max_value_nest_depth {
+            for value in captured {
+                value.check_max_depth(max_depth)?;
+            }
+        }
+    }
+    Ok(())
 }

--- a/third_party/move/move-vm/transactional-tests/tests/instructions/closure_pack_depth.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/instructions/closure_pack_depth.exp
@@ -1,0 +1,19 @@
+processed 4 tasks
+task 0 lines 1-40:  publish [module 0x99::closure_pack_depth {]
+task 1 lines 42-42:  run 0x99::closure_pack_depth::pack_within_limit
+task 2 lines 44-44:  run 0x99::closure_pack_depth::pack_too_deep
+Error: Function execution failed with VMError: {
+    major_status: VM_MAX_VALUE_DEPTH_REACHED,
+    sub_status: None,
+    location: 0x99::closure_pack_depth,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 9)],
+}
+task 3 lines 46-46:  run 0x99::closure_pack_depth::pack_at_limit_then_copy
+Error: Function execution failed with VMError: {
+    major_status: VM_MAX_VALUE_DEPTH_REACHED,
+    sub_status: None,
+    location: 0x99::closure_pack_depth,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(2), 3)],
+}

--- a/third_party/move/move-vm/transactional-tests/tests/instructions/closure_pack_depth.move
+++ b/third_party/move/move-vm/transactional-tests/tests/instructions/closure_pack_depth.move
@@ -1,0 +1,46 @@
+//# publish
+module 0x99::closure_pack_depth {
+
+    fun apply(f: |u64|u64 has copy + drop, x: u64): u64 {
+        f(x)
+    }
+
+    // Builds a chain of `n` closures, each capturing the previous one, so the value
+    // depth of the result grows with `n` while its type stays flat.
+    fun chain(n: u64): |u64|u64 has copy + drop {
+        let f: |u64|u64 has copy + drop = |x| x + 1;
+        let i = 0;
+        while (i < n) {
+            let g = f;
+            f = |x| apply(g, x);
+            i = i + 1;
+        };
+        f
+    }
+
+    // The deepest value captured by `chain(n)` is the chain of `n` closures, so 128
+    // is the largest chain the maximum value depth (128) allows to pack.
+    public fun pack_within_limit() {
+        let f = chain(128);
+        assert!(f(0) == 1, 0);
+    }
+
+    public fun pack_too_deep() {
+        chain(129);
+    }
+
+    // A closure packed at the limit is one level deeper than the maximum when counted
+    // from its own root (the captured chain plus the closure wrapper), so copying it
+    // fails even though packing it succeeded.
+    public fun pack_at_limit_then_copy() {
+        let f = chain(128);
+        let g = copy f;
+        assert!(g(0) == f(0), 0);
+    }
+}
+
+//# run 0x99::closure_pack_depth::pack_within_limit
+
+//# run 0x99::closure_pack_depth::pack_too_deep
+
+//# run 0x99::closure_pack_depth::pack_at_limit_then_copy

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -6030,3 +6030,184 @@ fn check_depth(depth: u64, max_depth: Option<u64>) -> PartialVMResult<()> {
     }
     Ok(())
 }
+
+/// Checks the depth of values
+struct ValueDepthChecker {
+    max_depth: u64,
+}
+
+impl ValueDepthChecker {
+    // Visitor depths are 0-based, while the serializer and `copy_value` count
+    // the root value as depth 1, so error when `depth + 1 > max_depth`.
+    fn check(&self, depth: u64) -> PartialVMResult<()> {
+        if depth >= self.max_depth {
+            return Err(PartialVMError::new(StatusCode::VM_MAX_VALUE_DEPTH_REACHED));
+        }
+        Ok(())
+    }
+
+    fn check_and_descend(&self, depth: u64) -> PartialVMResult<bool> {
+        self.check(depth)?;
+        Ok(true)
+    }
+}
+
+impl ValueVisitor for ValueDepthChecker {
+    fn visit_delayed(&mut self, depth: u64, _id: DelayedFieldID) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_u8(&mut self, depth: u64, _val: u8) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_u16(&mut self, depth: u64, _val: u16) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_u32(&mut self, depth: u64, _val: u32) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_u64(&mut self, depth: u64, _val: u64) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_u128(&mut self, depth: u64, _val: u128) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_u256(
+        &mut self,
+        depth: u64,
+        _val: &move_core_types::int256::U256,
+    ) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_i8(&mut self, depth: u64, _val: i8) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_i16(&mut self, depth: u64, _val: i16) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_i32(&mut self, depth: u64, _val: i32) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_i64(&mut self, depth: u64, _val: i64) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_i128(&mut self, depth: u64, _val: i128) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_i256(
+        &mut self,
+        depth: u64,
+        _val: &move_core_types::int256::I256,
+    ) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_bool(&mut self, depth: u64, _val: bool) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_address(&mut self, depth: u64, _val: &AccountAddress) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_struct(&mut self, depth: u64, _len: usize) -> PartialVMResult<bool> {
+        self.check_and_descend(depth)
+    }
+
+    fn visit_closure(&mut self, depth: u64, _len: usize) -> PartialVMResult<bool> {
+        self.check_and_descend(depth)
+    }
+
+    fn visit_vec(&mut self, depth: u64, _len: usize) -> PartialVMResult<bool> {
+        self.check_and_descend(depth)
+    }
+
+    fn visit_ref(&mut self, depth: u64, _is_global: bool) -> PartialVMResult<bool> {
+        self.check_and_descend(depth)
+    }
+
+    // Vectors of primitives count as a single nesting level: their elements do
+    // not add depth, matching the serializer and `copy_value`.
+
+    fn visit_vec_u8(&mut self, depth: u64, _vals: &[u8]) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_vec_u16(&mut self, depth: u64, _vals: &[u16]) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_vec_u32(&mut self, depth: u64, _vals: &[u32]) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_vec_u64(&mut self, depth: u64, _vals: &[u64]) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_vec_u128(&mut self, depth: u64, _vals: &[u128]) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_vec_u256(
+        &mut self,
+        depth: u64,
+        _vals: &[move_core_types::int256::U256],
+    ) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_vec_i8(&mut self, depth: u64, _vals: &[i8]) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_vec_i16(&mut self, depth: u64, _vals: &[i16]) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_vec_i32(&mut self, depth: u64, _vals: &[i32]) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_vec_i64(&mut self, depth: u64, _vals: &[i64]) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_vec_i128(&mut self, depth: u64, _vals: &[i128]) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_vec_i256(
+        &mut self,
+        depth: u64,
+        _vals: &[move_core_types::int256::I256],
+    ) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_vec_bool(&mut self, depth: u64, _vals: &[bool]) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+
+    fn visit_vec_address(&mut self, depth: u64, _vals: &[AccountAddress]) -> PartialVMResult<()> {
+        self.check(depth)
+    }
+}
+
+impl Value {
+    /// Returns an error if the nesting depth of the value exceeds `max_depth`.
+    pub fn check_max_depth(&self, max_depth: u64) -> PartialVMResult<()> {
+        self.visit(&mut ValueDepthChecker { max_depth })
+    }
+}


### PR DESCRIPTION
## Description

Adds a pack-time depth check for closure captured values in the Move VM interpreter.

The #364 backport (upstream #16983) bounds value depth in copy, equals/compare, `read_ref`, and (de)serialization. However, closures packed from **moved** captures never go through any of those checks: a loop like `let g = f; f = |x| apply(g, x);` re-captures by `MoveLoc`, so the captured chain grows without ever being copied, and `PackClosure`/`PackClosureGeneric` construct values of unbounded depth. Function types are the only types whose value depth is not bounded by their static type (`Pack` for structs is covered by the type-depth check), so this was the remaining gap.

The fix adds a `ValueDepthChecker` visitor in `move-vm-types` (exposed as `Value::check_max_depth`) and calls it on each captured value in both pack arms, gated on `enable_depth_checks` / `max_value_nest_depth`.

**Boundary semantics:** each captured value is counted from its own root (the new closure wrapper does not add a level), so captured values up to depth 128 are allowed and the packed closure may transiently reach total depth 129. This matches both the copy-time boundary (anything legal to copy is legal to capture) and upstream behavior as pinned by the existing `function_value_depth.rs` e2e test (`run2(128)` succeeds, `run2(129)` aborts). A closure packed at the limit aborts on later copy/compare/store, which count from the closure root; this transient overshoot is inherent (struct-packing over a max-depth closure field creates it too) and is documented and pinned by a test.

## How Has This Been Tested?

- New transactional test `move-vm/transactional-tests/tests/instructions/closure_pack_depth.move` pins the boundary with move-only captures (isolating the pack-time check): `chain(128)` packs and runs; `chain(129)` aborts with `VM_MAX_VALUE_DEPTH_REACHED` at the `PackClosure`; `chain(128)` followed by an explicit `copy` aborts at the `CopyLoc`.
- Existing e2e regression test `function_value_depth::test_vm_value_too_deep_with_function_values` (from #364) passes: `run2(128)` succeeds, `run2(129)` aborts.
- Full move-vm transactional-tests suite: 680/680 pass across all configs.
- `move-vm-types` `value_depth_tests` unit tests: all pass.

## Key Areas to Review

- **Boundary choice (128/129 vs 127/128)**: the check deliberately excludes the closure wrapper so pack agrees with the copy check and with upstream; the alternative (counting the wrapper) would reject values the VM just allowed to be copied and would break the #364 e2e expectations. See the doc comment on `check_captured_value_depths` in `interpreter.rs`.
- **`ValueDepthChecker` level counting** (`values_impl.rs`): struct/vector/closure children at +1; primitive-vector contents add no level and are checked O(1) via `visit_vec_*` overrides, matching `copy_value` and the serializer; references descend (unreachable for captures, which cannot contain references).
- **Check placement**: after `popn` of the captures and before `LazyLoadedFunction::new_resolved`, preserving the #354 verify-before-pack order.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation
