### PR TITLE
Add small-n coverage to the ristretto255 MSM benchmark

### DIFF
--- a/crates/aptos-crypto/benches/ristretto255.rs
+++ b/crates/aptos-crypto/benches/ristretto255.rs
@@ -43,9 +43,9 @@ fn benchmark_groups(c: &mut Criterion) {
     scalar_neg(&mut group);
     scalar_sub(&mut group);
 
-    //for n in 1..=128 {
-    //for n in [256, 512, 1024, 2048, 4096] {
-    for n in [2, 8192, 16384, 32768] {
+    // The small widths match the sigma-protocol MSMs that on-chain verification performs,
+    // which run to a few tens of points; the large ones exercise asymptotic scaling.
+    for n in [1, 2, 4, 8, 16, 32, 64, 128, 8192, 16384, 32768] {
         multi_scalar_mul(&mut group, n);
     }
 


### PR DESCRIPTION
## What

`multi_scalar_mul` in `crates/aptos-crypto/benches/ristretto255.rs` swept `n` at 2 and then jumped straight to 8192. The width range that on-chain sigma-protocol verification actually operates in was left unmeasured. This adds 1, 2, 4, 8, 16, 32, 64, 128 and keeps the existing large widths.

## Why

Sigma-protocol verification in the confidential asset proof module performs two multi-scalar multiplications per transfer, each over roughly 34 to 38 points (one term for the commitment, then one per balance chunk, per amount chunk, and per auditor). Nothing in the bench suite covered that range, so there was no way to attribute the cost of a confidential transfer between its batched range proofs and its sigma proof.

The two commented-out sweeps that previously sat above the active one are superseded and removed.

## Verification

```
cargo bench -p aptos-crypto --bench ristretto255 --no-run
cargo bench -p aptos-crypto --bench ristretto255 -- \
  "vartime_multiscalar_mul/(32|64)$" --measurement-time 2 --warm-up-time 1
```

Compiles, and both new widths produce measurements:

| n | time |
|---|---|
| 32 | 197.82 µs |
| 64 | 376.59 µs |

Benchmark-only change; no library or runtime code is touched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/movement-network/codesmith/aptos-core/pr/417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790182071&installation_model_id=17568&pr_number=417&repository=movement-network%2Faptos-core&return_to=https%3A%2F%2Fgithub.com%2Fmovement-network%2Faptos-core%2Fpull%2F417&signature=649c5c8eee386fb4ffded05b8841a25d738e49c88371332d47ebce0859a24c94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->