### PR TITLE
Add gas accounting tests for confidential transfers

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/confidential_asset.rs
+++ b/aptos-move/e2e-move-tests/src/tests/confidential_asset.rs
@@ -21,6 +21,10 @@
 // injected `confidential_asset` module.
 
 use crate::{tests::common::framework_dir_path, MoveHarness};
+use aptos_gas_schedule::{
+    gas_feature_versions, AptosGasParameters, InitialGasSchedule, ToOnChainGasSchedule,
+    LATEST_GAS_FEATURE_VERSION,
+};
 use aptos_language_e2e_tests::account::Account;
 use aptos_types::{
     account_address::AccountAddress,
@@ -607,14 +611,12 @@ fn pack_transfer_audited(
     std::array::from_fn(|i| ret.return_values[i].0.clone())
 }
 
-fn run_confidential_transfer(
-    h: &mut MoveHarness,
-    sender: &Account,
+fn confidential_transfer_payload(
     recipient: AccountAddress,
     parts: &[Vec<u8>; 8],
     sender_auditor_hint: Vec<u8>,
-) -> TransactionStatus {
-    let payload = TransactionPayload::EntryFunction(EntryFunction::new(
+) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
         ca_module_id(),
         Identifier::new("confidential_transfer").unwrap(),
         vec![],
@@ -631,7 +633,17 @@ fn run_confidential_transfer(
             parts[7].clone(),
             bcs::to_bytes(&sender_auditor_hint).unwrap(),
         ],
-    ));
+    ))
+}
+
+fn run_confidential_transfer(
+    h: &mut MoveHarness,
+    sender: &Account,
+    recipient: AccountAddress,
+    parts: &[Vec<u8>; 8],
+    sender_auditor_hint: Vec<u8>,
+) -> TransactionStatus {
+    let payload = confidential_transfer_payload(recipient, parts, sender_auditor_hint);
     let txn = h.create_transaction_payload(sender, payload);
     h.run(txn)
 }
@@ -1311,5 +1323,112 @@ fn deposit_normalize_and_rollover_succeeds_when_not_normalized() {
     assert_kept_success(
         &run_deposit_normalize_and_rollover(&mut h, &alice, 50, &new_bal, &zkrp, &sigma),
         "deposit_normalize_and_rollover when not normalized",
+    );
+}
+
+// --- Gas accounting ---
+
+/// The gas feature version immediately below `RELEASE_V1_28`, where the
+/// `bulletproofs.verify.base_batch_*` parameters are introduced. Below that version those
+/// parameters are absent from the schedule, and parameter resolution leaves absent entries at
+/// zero rather than failing, so batched range-proof verification is charged nothing.
+const PRE_BATCH_RANGEPROOF_GAS_VERSION: u64 = gas_feature_versions::RELEASE_V1_27;
+
+fn pin_gas_feature_version(h: &mut MoveHarness, feature_version: u64) {
+    h.modify_gas_schedule_raw(|gas_schedule| {
+        gas_schedule.feature_version = feature_version;
+        gas_schedule.entries =
+            AptosGasParameters::initial().to_on_chain_gas_schedule(feature_version);
+    });
+}
+
+/// Runs one `confidential_transfer` end to end and returns the gas charged for it. The gas
+/// schedule is pinned only after setup, so both feature versions measure the same transfer
+/// against identical state.
+fn confidential_transfer_gas_used(pinned_gas_feature_version: Option<u64>, idx: u8) -> u64 {
+    let mut h = fresh_harness();
+    let chain = h.executor.get_chain_id().id();
+    let alice_addr = confidential_e2e_addr(0xA1, idx);
+    let bob_addr = confidential_e2e_addr(0xA2, idx);
+    let alice = h.new_account_with_balance_at(alice_addr, 50_000_000_000_000);
+    let bob = h.new_account_with_balance_at(bob_addr, 1_000_000_000);
+
+    let (alice_dk, alice_ek) = generate_elgamal_keypair(&mut h);
+    let (bob_dk, bob_ek) = generate_elgamal_keypair(&mut h);
+    for (acct, addr, dk, ek) in [
+        (&alice, alice_addr, &alice_dk, &alice_ek),
+        (&bob, bob_addr, &bob_dk, &bob_ek),
+    ] {
+        let pk = twisted_pubkey_bytes(&mut h, ek);
+        let (c, r) = prove_registration_parts(&mut h, chain, addr, dk, ek, MOVE_METADATA);
+        assert_kept_success(&run_register(&mut h, acct, &pk, &c, &r), "register");
+    }
+
+    assert_kept_success(&run_deposit(&mut h, &alice, 8_000), "deposit");
+    assert_kept_success(&run_rollover(&mut h, &alice), "rollover");
+
+    let parts = pack_transfer_simple(
+        &mut h,
+        chain,
+        alice_addr,
+        bob_addr,
+        &alice_dk,
+        200,
+        7_800,
+        vec![],
+    );
+
+    if let Some(feature_version) = pinned_gas_feature_version {
+        pin_gas_feature_version(&mut h, feature_version);
+    }
+
+    let payload = confidential_transfer_payload(bob_addr, &parts, vec![]);
+    let txn = h.create_transaction_payload(&alice, payload);
+    let output = h.run_raw(txn);
+    assert_kept_success(output.status(), "transfer");
+    output.gas_used()
+}
+
+/// External-gas cost of the two batched range proofs a transfer verifies, over the 8 chunks
+/// of the new balance and the 4 chunks of the transfer amount.
+fn batch_rangeproof_gas_cost() -> u64 {
+    let params = AptosGasParameters::initial();
+    let internal = u64::from(
+        params
+            .natives
+            .aptos_framework
+            .bulletproofs_verify_base_batch_8_bits_16,
+    ) + u64::from(
+        params
+            .natives
+            .aptos_framework
+            .bulletproofs_verify_base_batch_4_bits_16,
+    );
+    internal / u64::from(params.vm.txn.scaling_factor())
+}
+
+/// A confidential transfer verifies two batched range proofs, over the 8 chunks of the new
+/// balance and the 4 chunks of the transfer amount. Below `RELEASE_V1_28` their gas
+/// parameters resolve to zero, so the transfer still succeeds but pays nothing for that
+/// verification. This pins both halves of that behaviour: the transfer is accepted either
+/// way, and the gap it leaves is exactly the two parameters.
+#[test]
+fn confidential_transfer_batch_rangeproof_gas_is_version_gated() {
+    let priced = confidential_transfer_gas_used(None, 1);
+    let unpriced = confidential_transfer_gas_used(Some(PRE_BATCH_RANGEPROOF_GAS_VERSION), 2);
+    let expected = batch_rangeproof_gas_cost();
+
+    assert_eq!(
+        priced - unpriced,
+        expected,
+        "a transfer costs {priced} at gas feature version {LATEST_GAS_FEATURE_VERSION} and \
+         {unpriced} at {PRE_BATCH_RANGEPROOF_GAS_VERSION}; the gap should be exactly the two \
+         batch range-proof parameters ({expected})"
+    );
+
+    println!(
+        "confidential_transfer gas: {priced} at gas feature version {}, {unpriced} at {}; \
+         batch range-proof verification accounts for {expected}",
+        LATEST_GAS_FEATURE_VERSION, PRE_BATCH_RANGEPROOF_GAS_VERSION,
     );
 }

--- a/aptos-move/e2e-move-tests/src/tests/confidential_asset.rs
+++ b/aptos-move/e2e-move-tests/src/tests/confidential_asset.rs
@@ -1432,3 +1432,73 @@ fn confidential_transfer_batch_rangeproof_gas_is_version_gated() {
         LATEST_GAS_FEATURE_VERSION, PRE_BATCH_RANGEPROOF_GAS_VERSION,
     );
 }
+
+/// Breaks a confidential transfer's gas down by operation. Asserts the two batched range
+/// proofs are charged exactly what their parameters say and remain the single largest line
+/// item, and prints the rest so the composition is visible when it shifts.
+#[test]
+fn confidential_transfer_gas_profile() {
+    let mut h = fresh_harness();
+    let chain = h.executor.get_chain_id().id();
+    let alice_addr = confidential_e2e_addr(0xA3, 1);
+    let bob_addr = confidential_e2e_addr(0xA4, 1);
+    let alice = h.new_account_with_balance_at(alice_addr, 50_000_000_000_000);
+    let bob = h.new_account_with_balance_at(bob_addr, 1_000_000_000);
+
+    let (alice_dk, alice_ek) = generate_elgamal_keypair(&mut h);
+    let (bob_dk, bob_ek) = generate_elgamal_keypair(&mut h);
+    for (acct, addr, dk, ek) in [
+        (&alice, alice_addr, &alice_dk, &alice_ek),
+        (&bob, bob_addr, &bob_dk, &bob_ek),
+    ] {
+        let pk = twisted_pubkey_bytes(&mut h, ek);
+        let (c, r) = prove_registration_parts(&mut h, chain, addr, dk, ek, MOVE_METADATA);
+        assert_kept_success(&run_register(&mut h, acct, &pk, &c, &r), "register");
+    }
+    assert_kept_success(&run_deposit(&mut h, &alice, 8_000), "deposit");
+    assert_kept_success(&run_rollover(&mut h, &alice), "rollover");
+
+    let parts = pack_transfer_simple(
+        &mut h,
+        chain,
+        alice_addr,
+        bob_addr,
+        &alice_dk,
+        200,
+        7_800,
+        vec![],
+    );
+    let payload = confidential_transfer_payload(bob_addr, &parts, vec![]);
+
+    let (log, gas_used, _fee) = h.evaluate_gas_with_profiler(&alice, payload);
+    let io = &log.exec_io;
+    let scale = u64::from(io.gas_scaling_factor);
+    let aggregated = io.aggregate_gas_events();
+
+    println!("confidential_transfer: {gas_used} gas, intrinsic {}", u64::from(io.intrinsic_cost) / scale);
+    for (name, count, cost) in &aggregated.ops {
+        let cost = u64::from(*cost) / scale;
+        if cost > 0 {
+            println!("  {cost:>5}  x{count:<6} {name}");
+        }
+    }
+
+    let (_, count, cost) = aggregated
+        .ops
+        .iter()
+        .find(|(name, _, _)| name.contains("verify_batch_range_proof"))
+        .expect("a transfer must verify batched range proofs");
+    assert_eq!(*count, 2, "a transfer verifies two batched range proofs");
+    assert_eq!(
+        u64::from(*cost) / scale,
+        batch_rangeproof_gas_cost(),
+        "range-proof verification should be charged exactly its two parameters"
+    );
+
+    let largest = u64::from(aggregated.ops[0].2) / scale;
+    assert_eq!(
+        largest,
+        batch_rangeproof_gas_cost(),
+        "range-proof verification should be the largest single cost in a transfer"
+    );
+}


### PR DESCRIPTION
## What

Two tests for the gas accounting of a confidential transfer.

**`confidential_transfer_batch_rangeproof_gas_is_version_gated`** runs the same transfer at the current gas feature version and at `RELEASE_V1_27`, asserting that it succeeds at **both** and that the gas difference is **exactly** `bulletproofs.verify.base_batch_8_bits_16` plus `bulletproofs.verify.base_batch_4_bits_16`, over the gas unit scaling factor.

**`confidential_transfer_gas_profile`** breaks a transfer down by operation with the gas profiler, asserting the two batched range proofs are charged exactly their parameters and remain the largest single line item, and printing the rest so a shift in composition is visible.

## Why the version gate matters

A transfer verifies two batched range proofs, over the 8 chunks of the new balance and the 4 chunks of the transfer amount. Their gas parameters are gated `RELEASE_V1_28..`. Below that version they are absent from the schedule, and `from_on_chain_gas_schedule` leaves absent entries at their `zeros()` initial value rather than returning an error, so `charge_batch_gas` charges nothing. The batch path has no base or per-byte parameter to fall back on, unlike the non-batch path.

So a chain running a gas schedule below `RELEASE_V1_28` accepts confidential transfers without charging for the dominant part of their verification cost. Nothing in the suite covered this, because `MoveHarness` builds its schedule at `LATEST_GAS_FEATURE_VERSION`, so the tests have only ever exercised the priced path.

`RELEASE_V1_28` gates the 20 `base_batch` parameters and nothing else, so pinning one version below makes the whole delta attributable to batched range-proof verification.

## What the profile shows

The test prints gas in the e2e harness's units, where `gas_unit_scaling_factor` is 1,000,000. Mainnet and testnet run at ~50,000, a 20x finer unit, so the right-hand column converts for scale. A transfer is 366 harness units, roughly 7,320 on mainnet.

| share | harness units | mainnet equiv. | what |
|---|---|---|---|
| 52% | 190 | 3,806 | `verify_batch_range_proof_internal` x2 |
| 22% | ~78 | ~1,560 | Move interpreter overhead |
| 17% | ~62 | ~1,240 | other `ristretto255` natives |
| 2% | 7 | 140 | intrinsic |
| <1% | ~1 | ~20 | storage and io |
| | **366** | **~7,320** | total |

Only the first row is exact: `(120974478 + 69359728)` internal gas, divided by 1,000,000 for the harness column and by 50,000 for the mainnet one. The middle rows are sums of individually-rounded line items and are approximate.

The interpreter share comes from instruction counts rather than expensive instructions: 20,092 `copy_loc`, 18,322 `create_ty`, 11,233 `move_loc`, 8,245 `st_loc`, 4,338 `vec_push_back`, all building and copying vectors of points and scalars. The other-natives share is dominated by 110 `point_decompress` and 93 `point_compress` calls, so points are round-tripped between representations rather than held in one.

Intrinsic cost is negligible, so transaction payload size is not a factor despite the size of the proofs.

## Also

Extracts `confidential_transfer_payload` out of `run_confidential_transfer` so both tests can submit the same payload through `run_raw` and `evaluate_gas_with_profiler`. No behaviour change for existing callers.

## Verification

```
cargo build -p e2e-move-tests --tests
RUST_MIN_STACK=33554432 cargo test -p e2e-move-tests --lib tests::confidential_asset:: -- --test-threads=4
```

All 16 tests in the module pass, the 14 pre-existing ones included:

```
test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 254 filtered out; finished in 88.11s
```

The version-gate test reports:

```
confidential_transfer gas: 366 at gas feature version 36, 176 at 31;
batch range-proof verification accounts for 190
```

190 is `(120974478 + 69359728) / 1000000`, matching the two parameters exactly.

`RUST_MIN_STACK` is needed to run this module at all; the pre-existing tests overflow the default stack in a debug build without it. The value above matches what CI sets in `lint-test.yaml`.

`rustfmt` and `clippy` are clean over the added code. The file carries pre-existing diffs from both on the base branch (lines 25, 66, 203), left untouched rather than mixed into this diff.

