### PR TITLE
Do not allow serialization of function values by default

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -152,6 +152,7 @@ pub enum FeatureFlag {
     GovernedGasPool,
     SteakRewardUsingTreasury,
     ExtractAbortInfoExactMatch,
+    EnableFunctionValueBcsSerialization,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -403,6 +404,9 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::ExtractAbortInfoExactMatch => {
                 AptosFeatureFlag::EXTRACT_ABORT_INFO_EXACT_MATCH
             },
+            FeatureFlag::EnableFunctionValueBcsSerialization => {
+                AptosFeatureFlag::ENABLE_FUNCTION_VALUE_BCS_SERIALIZATION
+            },
         }
     }
 }
@@ -580,6 +584,9 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             AptosFeatureFlag::STAKE_REWARD_USING_TREASURY => FeatureFlag::SteakRewardUsingTreasury,
             AptosFeatureFlag::EXTRACT_ABORT_INFO_EXACT_MATCH => {
                 FeatureFlag::ExtractAbortInfoExactMatch
+            },
+            AptosFeatureFlag::ENABLE_FUNCTION_VALUE_BCS_SERIALIZATION => {
+                FeatureFlag::EnableFunctionValueBcsSerialization
             },
         }
     }

--- a/aptos-move/e2e-move-tests/src/tests/aggregator_v2_function_values.rs
+++ b/aptos-move/e2e-move-tests/src/tests/aggregator_v2_function_values.rs
@@ -5,7 +5,9 @@ use crate::{assert_success, assert_vm_status, tests::common, MoveHarness};
 use aptos_framework::BuildOptions;
 use aptos_language_e2e_tests::executor::FakeExecutor;
 use aptos_transaction_simulation::Account;
-use aptos_types::{move_utils::MemberId, transaction::ExecutionStatus};
+use aptos_types::{
+    move_utils::MemberId, on_chain_config::FeatureFlag, transaction::ExecutionStatus,
+};
 use claims::assert_ok;
 use move_core_types::{
     account_address::AccountAddress, parser::parse_struct_tag, vm_status::StatusCode,
@@ -138,6 +140,9 @@ fn test_function_value_uses_aggregator_is_storable() {
 #[test]
 fn test_function_value_captures_aggregator() {
     let mut h = MoveHarness::new_with_executor(FakeExecutor::from_head_genesis().set_parallel());
+    // This test is about capturing an aggregator, so allow function values to be serialized:
+    // otherwise serialization fails before the captured aggregator is even reached.
+    h.enable_features(vec![FeatureFlag::ENABLE_FUNCTION_VALUE_BCS_SERIALIZATION], vec![]);
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0x123").unwrap());
     initialize(&mut h);
 

--- a/aptos-move/e2e-move-tests/src/tests/any.rs
+++ b/aptos-move/e2e-move-tests/src/tests/any.rs
@@ -3,11 +3,15 @@
 
 use crate::{assert_abort, assert_success, tests::common, MoveHarness};
 use aptos_framework::BuildOptions;
+use aptos_types::on_chain_config::FeatureFlag;
 use move_core_types::account_address::AccountAddress;
 
 #[test]
 fn test_any_with_function_values() {
     let mut h = MoveHarness::new();
+    // `any::pack` serializes the value with `bcs::to_bytes`, which is only allowed for values
+    // containing function values while the feature below is enabled.
+    h.enable_features(vec![FeatureFlag::ENABLE_FUNCTION_VALUE_BCS_SERIALIZATION], vec![]);
 
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0x123").unwrap());
     assert_success!(h.publish_package_with_options(

--- a/aptos-move/e2e-move-tests/src/tests/function_value_bcs_serialization.rs
+++ b/aptos-move/e2e-move-tests/src/tests/function_value_bcs_serialization.rs
@@ -1,0 +1,257 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for `ENABLE_FUNCTION_VALUE_BCS_SERIALIZATION`: while the feature is off, BCS bytes of
+//! function values cannot be observed by Move code (`bcs` natives and table keys), so no
+//! on-chain state can be derived from a function value format which is not yet stable.
+//! Storage writes, events, table values and calling stored function values are unaffected.
+
+use crate::{assert_abort, assert_success, tests::common, MoveHarness};
+use aptos_framework::BuildOptions;
+use aptos_language_e2e_tests::account::Account;
+use aptos_package_builder::PackageBuilder;
+use aptos_types::{
+    account_address::AccountAddress,
+    on_chain_config::FeatureFlag,
+    transaction::{ExecutionStatus, TransactionStatus},
+};
+use move_core_types::vm_status::{sub_status::NFE_BCS_SERIALIZATION_FAILURE, AbortLocation};
+
+const SOURCE: &str = r#"
+module 0x66::m {
+    use std::bcs;
+    use std::option;
+    use std::signer;
+    use aptos_std::aptos_hash;
+    use aptos_std::table;
+    use aptos_framework::event;
+
+    // A function value can only be stored if it refers to a persistent function.
+    #[persistent]
+    fun add_to(x: u64, y: u64): u64 { x + y }
+
+    struct Wrapper has copy, drop, store { tag: u8, f: |u64|u64 has copy+store+drop }
+
+    struct KeyedTable has key { t: table::Table<|u64|u64 has copy+store+drop, u64> }
+
+    struct ValuedTable has key { t: table::Table<u64, |u64|u64 has copy+store+drop> }
+
+    struct Holder has key { f: |u64|u64 has copy+store+drop }
+
+    #[event]
+    struct Emitted has drop, store { f: |u64|u64 has copy+store+drop }
+
+    fun captured(): |u64|u64 has copy+store+drop {
+        |y| add_to(10, y)
+    }
+
+    // ---- Values whose BCS bytes are observed by Move code.
+
+    public entry fun to_bytes_captured() {
+        let _ = bcs::to_bytes(&captured());
+    }
+
+    public entry fun to_bytes_not_captured() {
+        // A function value which captures nothing still serializes its identity.
+        let f: |u64, u64|u64 has copy+store+drop = add_to;
+        let _ = bcs::to_bytes(&f);
+    }
+
+    public entry fun to_bytes_nested() {
+        let _ = bcs::to_bytes(&vector[Wrapper { tag: 1, f: captured() }]);
+    }
+
+    public entry fun serialized_size_captured() {
+        let _ = bcs::serialized_size(&captured());
+    }
+
+    public entry fun sip_hash_captured() {
+        let _ = aptos_hash::sip_hash_from_value(&captured());
+    }
+
+    // A value of function type which does not hold a function value is not restricted.
+    public entry fun to_bytes_no_function_value() {
+        let _ = bcs::to_bytes(&option::none<|u64|u64 has copy+store+drop>());
+    }
+
+    // ---- Tables keyed by a function value.
+
+    public entry fun init_keyed_table(s: &signer) {
+        move_to(s, KeyedTable { t: table::new() })
+    }
+
+    public entry fun table_add_key(s: &signer) acquires KeyedTable {
+        let t = &mut borrow_global_mut<KeyedTable>(signer::address_of(s)).t;
+        table::add(t, captured(), 1)
+    }
+
+    public entry fun table_contains_key(s: &signer) acquires KeyedTable {
+        let t = &borrow_global<KeyedTable>(signer::address_of(s)).t;
+        assert!(table::contains(t, captured()), 0)
+    }
+
+    public entry fun table_borrow_key(s: &signer) acquires KeyedTable {
+        let t = &borrow_global<KeyedTable>(signer::address_of(s)).t;
+        assert!(*table::borrow(t, captured()) == 1, 0)
+    }
+
+    public entry fun table_remove_key(s: &signer) acquires KeyedTable {
+        let t = &mut borrow_global_mut<KeyedTable>(signer::address_of(s)).t;
+        assert!(table::remove(t, captured()) == 1, 0)
+    }
+
+    // ---- Paths whose bytes are not observable by Move code.
+
+    public entry fun table_function_value(s: &signer) {
+        let t = table::new<u64, |u64|u64 has copy+store+drop>();
+        table::add(&mut t, 1, captured());
+        move_to(s, ValuedTable { t })
+    }
+
+    public entry fun store_function_value(s: &signer) {
+        move_to(s, Holder { f: captured() })
+    }
+
+    public entry fun emit_function_value() {
+        event::emit(Emitted { f: captured() })
+    }
+
+    public entry fun call_stored(s: &signer, x: u64, expected: u64) acquires Holder {
+        let f = borrow_global<Holder>(signer::address_of(s)).f;
+        assert!(f(x) == expected, 1)
+    }
+}
+"#;
+
+/// Operations which make the BCS bytes of a function value observable to Move code.
+const BCS_OPERATIONS: [&str; 5] = [
+    "to_bytes_captured",
+    "to_bytes_not_captured",
+    "to_bytes_nested",
+    "serialized_size_captured",
+    "sip_hash_captured",
+];
+
+/// Table operations with a key containing a function value.
+const KEYED_TABLE_OPERATIONS: [&str; 4] = [
+    "table_add_key",
+    "table_contains_key",
+    "table_borrow_key",
+    "table_remove_key",
+];
+
+fn setup() -> (MoveHarness, Account) {
+    let mut builder = PackageBuilder::new("Package");
+    builder.add_source("m.move", SOURCE);
+    builder.add_local_dep(
+        "AptosFramework",
+        &common::framework_dir_path("aptos-framework").to_string_lossy(),
+    );
+    let path = builder.write_to_temp().unwrap();
+
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0x66").unwrap());
+    assert_success!(h.publish_package_with_options(
+        &acc,
+        path.path(),
+        BuildOptions::move_2().set_latest_language()
+    ));
+    (h, acc)
+}
+
+fn run(h: &mut MoveHarness, acc: &Account, name: &str) -> TransactionStatus {
+    h.run_entry_function(
+        acc,
+        str::parse(&format!("0x66::m::{}", name)).unwrap(),
+        vec![],
+        vec![],
+    )
+}
+
+/// A table key which cannot be serialized surfaces as a failure of the table extension,
+/// attributed to `0x1::table` - the same shape as any other unusable key.
+fn assert_table_key_failure(status: TransactionStatus, name: &str) {
+    assert!(
+        matches!(
+            &status,
+            TransactionStatus::Keep(ExecutionStatus::ExecutionFailure {
+                location: AbortLocation::Module(module),
+                ..
+            }) if module.address() == &AccountAddress::ONE && module.name().as_str() == "table"
+        ),
+        "{}: {:?}",
+        name,
+        status
+    );
+}
+
+fn assert_unaffected_operations_succeed(h: &mut MoveHarness, acc: &Account) {
+    assert_success!(run(h, acc, "to_bytes_no_function_value"));
+    assert_success!(run(h, acc, "store_function_value"));
+    assert_success!(run(h, acc, "table_function_value"));
+    assert_success!(run(h, acc, "emit_function_value"));
+    assert_success!(h.run_entry_function(
+        acc,
+        str::parse("0x66::m::call_stored").unwrap(),
+        vec![],
+        vec![
+            bcs::to_bytes(&5u64).unwrap(),
+            bcs::to_bytes(&15u64).unwrap()
+        ],
+    ));
+}
+
+#[test]
+fn function_value_bcs_serialization_is_disabled_by_default() {
+    let (mut h, acc) = setup();
+    assert_success!(run(&mut h, &acc, "init_keyed_table"));
+
+    for name in BCS_OPERATIONS {
+        assert_abort!(
+            run(&mut h, &acc, name),
+            NFE_BCS_SERIALIZATION_FAILURE,
+            "{}",
+            name
+        );
+    }
+    for name in KEYED_TABLE_OPERATIONS {
+        assert_table_key_failure(run(&mut h, &acc, name), name);
+    }
+
+    assert_unaffected_operations_succeed(&mut h, &acc);
+}
+
+#[test]
+fn function_value_bcs_serialization_works_while_enabled() {
+    let (mut h, acc) = setup();
+    h.enable_features(vec![FeatureFlag::ENABLE_FUNCTION_VALUE_BCS_SERIALIZATION], vec![]);
+    assert_success!(run(&mut h, &acc, "init_keyed_table"));
+
+    for name in BCS_OPERATIONS {
+        assert_success!(run(&mut h, &acc, name), "{}", name);
+    }
+    for name in KEYED_TABLE_OPERATIONS {
+        assert_success!(run(&mut h, &acc, name), "{}", name);
+    }
+
+    assert_unaffected_operations_succeed(&mut h, &acc);
+}
+
+/// Entries stored under a function value key while the feature was on cannot be reached
+/// once it is turned off again - they are not lost, just unaddressable.
+#[test]
+fn function_value_table_keys_are_unreachable_while_disabled() {
+    let (mut h, acc) = setup();
+    h.enable_features(vec![FeatureFlag::ENABLE_FUNCTION_VALUE_BCS_SERIALIZATION], vec![]);
+    assert_success!(run(&mut h, &acc, "init_keyed_table"));
+    assert_success!(run(&mut h, &acc, "table_add_key"));
+
+    h.enable_features(vec![], vec![FeatureFlag::ENABLE_FUNCTION_VALUE_BCS_SERIALIZATION]);
+    for name in ["table_contains_key", "table_borrow_key", "table_remove_key"] {
+        assert_table_key_failure(run(&mut h, &acc, name), name);
+    }
+
+    h.enable_features(vec![FeatureFlag::ENABLE_FUNCTION_VALUE_BCS_SERIALIZATION], vec![]);
+    assert_success!(run(&mut h, &acc, "table_borrow_key"));
+    assert_success!(run(&mut h, &acc, "table_remove_key"));
+}

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -23,6 +23,7 @@ mod enum_variant_tag_serialization;
 mod error_map;
 mod events;
 mod fee_payer;
+mod function_value_bcs_serialization;
 mod function_value_depth;
 mod function_values;
 mod fungible_asset;

--- a/aptos-move/framework/aptos-framework/doc/aptos_governance.md
+++ b/aptos-move/framework/aptos-framework/doc/aptos_governance.md
@@ -37,6 +37,8 @@ on a proposal multiple times as long as the total voting power of these votes do
 -  [Function `initialize`](#0x1_aptos_governance_initialize)
 -  [Function `update_governance_config`](#0x1_aptos_governance_update_governance_config)
 -  [Function `initialize_partial_voting`](#0x1_aptos_governance_initialize_partial_voting)
+-  [Function `partial_voting_initialized`](#0x1_aptos_governance_partial_voting_initialized)
+-  [Function `initialize_partial_voting_if_needed`](#0x1_aptos_governance_initialize_partial_voting_if_needed)
 -  [Function `get_voting_duration_secs`](#0x1_aptos_governance_get_voting_duration_secs)
 -  [Function `get_min_voting_threshold`](#0x1_aptos_governance_get_min_voting_threshold)
 -  [Function `get_required_proposer_stake`](#0x1_aptos_governance_get_required_proposer_stake)
@@ -72,6 +74,8 @@ on a proposal multiple times as long as the total voting power of these votes do
     -  [Function `initialize`](#@Specification_1_initialize)
     -  [Function `update_governance_config`](#@Specification_1_update_governance_config)
     -  [Function `initialize_partial_voting`](#@Specification_1_initialize_partial_voting)
+    -  [Function `partial_voting_initialized`](#@Specification_1_partial_voting_initialized)
+    -  [Function `initialize_partial_voting_if_needed`](#@Specification_1_initialize_partial_voting_if_needed)
     -  [Function `get_voting_duration_secs`](#@Specification_1_get_voting_duration_secs)
     -  [Function `get_min_voting_threshold`](#@Specification_1_get_min_voting_threshold)
     -  [Function `get_required_proposer_stake`](#@Specification_1_get_required_proposer_stake)
@@ -1094,6 +1098,65 @@ proposals with a signer for the aptos_framework (0x1) account.
     <b>move_to</b>(aptos_framework, <a href="aptos_governance.md#0x1_aptos_governance_VotingRecordsV2">VotingRecordsV2</a> {
         votes: <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_new">smart_table::new</a>(),
     });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_aptos_governance_partial_voting_initialized"></a>
+
+## Function `partial_voting_initialized`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_partial_voting_initialized">partial_voting_initialized</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_partial_voting_initialized">partial_voting_initialized</a>(): bool {
+    <b>exists</b>&lt;<a href="aptos_governance.md#0x1_aptos_governance_VotingRecordsV2">VotingRecordsV2</a>&gt;(@aptos_framework)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_aptos_governance_initialize_partial_voting_if_needed"></a>
+
+## Function `initialize_partial_voting_if_needed`
+
+Initializes the state for Aptos Governance partial voting if it has not already been initialized.
+This can only be called with a signer for the aptos_framework (0x1) account.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_initialize_partial_voting_if_needed">initialize_partial_voting_if_needed</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_initialize_partial_voting_if_needed">initialize_partial_voting_if_needed</a>(
+    aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+) {
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
+
+    <b>if</b> (!<a href="aptos_governance.md#0x1_aptos_governance_partial_voting_initialized">partial_voting_initialized</a>()) {
+        <b>move_to</b>(aptos_framework, <a href="aptos_governance.md#0x1_aptos_governance_VotingRecordsV2">VotingRecordsV2</a> {
+            votes: <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_new">smart_table::new</a>(),
+        });
+    }
 }
 </code></pre>
 
@@ -2314,6 +2377,44 @@ Abort if structs have already been created.
 <pre><code><b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework);
 <b>aborts_if</b> addr != @aptos_framework;
 <b>aborts_if</b> <b>exists</b>&lt;<a href="aptos_governance.md#0x1_aptos_governance_VotingRecordsV2">VotingRecordsV2</a>&gt;(@aptos_framework);
+<b>ensures</b> <b>exists</b>&lt;<a href="aptos_governance.md#0x1_aptos_governance_VotingRecordsV2">VotingRecordsV2</a>&gt;(@aptos_framework);
+</code></pre>
+
+
+
+<a id="@Specification_1_partial_voting_initialized"></a>
+
+### Function `partial_voting_initialized`
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_partial_voting_initialized">partial_voting_initialized</a>(): bool
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == <b>exists</b>&lt;<a href="aptos_governance.md#0x1_aptos_governance_VotingRecordsV2">VotingRecordsV2</a>&gt;(@aptos_framework);
+</code></pre>
+
+
+
+<a id="@Specification_1_initialize_partial_voting_if_needed"></a>
+
+### Function `initialize_partial_voting_if_needed`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_initialize_partial_voting_if_needed">initialize_partial_voting_if_needed</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+Signer address must be @aptos_framework.
+
+
+<pre><code><b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework);
+<b>aborts_if</b> addr != @aptos_framework;
 <b>ensures</b> <b>exists</b>&lt;<a href="aptos_governance.md#0x1_aptos_governance_VotingRecordsV2">VotingRecordsV2</a>&gt;(@aptos_framework);
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/delegation_pool.md
+++ b/aptos-move/framework/aptos-framework/doc/delegation_pool.md
@@ -152,6 +152,7 @@ transferred to A
 -  [Function `owner_cap_exists`](#0x1_delegation_pool_owner_cap_exists)
 -  [Function `get_owned_pool_address`](#0x1_delegation_pool_get_owned_pool_address)
 -  [Function `delegation_pool_exists`](#0x1_delegation_pool_delegation_pool_exists)
+-  [Function `governance_records_initialized`](#0x1_delegation_pool_governance_records_initialized)
 -  [Function `partial_governance_voting_enabled`](#0x1_delegation_pool_partial_governance_voting_enabled)
 -  [Function `observed_lockup_cycle`](#0x1_delegation_pool_observed_lockup_cycle)
 -  [Function `is_next_commission_percentage_effective`](#0x1_delegation_pool_is_next_commission_percentage_effective)
@@ -179,6 +180,7 @@ transferred to A
 -  [Function `initialize_delegation_pool`](#0x1_delegation_pool_initialize_delegation_pool)
 -  [Function `beneficiary_for_operator`](#0x1_delegation_pool_beneficiary_for_operator)
 -  [Function `enable_partial_governance_voting`](#0x1_delegation_pool_enable_partial_governance_voting)
+-  [Function `enable_partial_governance_voting_if_needed`](#0x1_delegation_pool_enable_partial_governance_voting_if_needed)
 -  [Function `vote`](#0x1_delegation_pool_vote)
 -  [Function `create_proposal`](#0x1_delegation_pool_create_proposal)
 -  [Function `assert_owner_cap_exists`](#0x1_delegation_pool_assert_owner_cap_exists)
@@ -2122,6 +2124,32 @@ Return whether a delegation pool exists at supplied address <code>addr</code>.
 
 </details>
 
+<a id="0x1_delegation_pool_governance_records_initialized"></a>
+
+## Function `governance_records_initialized`
+
+Return whether a delegation pool has governance records initialized.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_governance_records_initialized">governance_records_initialized</a>(pool_address: <b>address</b>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_governance_records_initialized">governance_records_initialized</a>(pool_address: <b>address</b>): bool {
+    <b>exists</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_GovernanceRecords">GovernanceRecords</a>&gt;(pool_address)
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_delegation_pool_partial_governance_voting_enabled"></a>
 
 ## Function `partial_governance_voting_enabled`
@@ -2140,7 +2168,7 @@ Return whether a delegation pool has already enabled partial governance voting.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_partial_governance_voting_enabled">partial_governance_voting_enabled</a>(pool_address: <b>address</b>): bool {
-    <b>exists</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_GovernanceRecords">GovernanceRecords</a>&gt;(pool_address) && <a href="stake.md#0x1_stake_get_delegated_voter">stake::get_delegated_voter</a>(pool_address) == pool_address
+    <a href="delegation_pool.md#0x1_delegation_pool_governance_records_initialized">governance_records_initialized</a>(pool_address) && <a href="stake.md#0x1_stake_get_delegated_voter">stake::get_delegated_voter</a>(pool_address) == pool_address
 }
 </code></pre>
 
@@ -3078,6 +3106,37 @@ The existing voter will be replaced. The function is permissionless.
         create_proposal_events: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="delegation_pool.md#0x1_delegation_pool_CreateProposalEvent">CreateProposalEvent</a>&gt;(&stake_pool_signer),
         delegate_voting_power_events: <a href="account.md#0x1_account_new_event_handle">account::new_event_handle</a>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegateVotingPowerEvent">DelegateVotingPowerEvent</a>&gt;(&stake_pool_signer),
     });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_delegation_pool_enable_partial_governance_voting_if_needed"></a>
+
+## Function `enable_partial_governance_voting_if_needed`
+
+Enable partial governance voting on a delegation pool if it has not already been initialized.
+This is intended for idempotent migration scripts over existing delegation pools.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_enable_partial_governance_voting_if_needed">enable_partial_governance_voting_if_needed</a>(pool_address: <b>address</b>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_enable_partial_governance_voting_if_needed">enable_partial_governance_voting_if_needed</a>(
+    pool_address: <b>address</b>,
+) <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>, <a href="delegation_pool.md#0x1_delegation_pool_GovernanceRecords">GovernanceRecords</a>, <a href="delegation_pool.md#0x1_delegation_pool_BeneficiaryForOperator">BeneficiaryForOperator</a>, <a href="delegation_pool.md#0x1_delegation_pool_NextCommissionPercentage">NextCommissionPercentage</a> {
+    <a href="delegation_pool.md#0x1_delegation_pool_assert_delegation_pool_exists">assert_delegation_pool_exists</a>(pool_address);
+    <b>if</b> (!<a href="delegation_pool.md#0x1_delegation_pool_governance_records_initialized">governance_records_initialized</a>(pool_address)) {
+        <a href="delegation_pool.md#0x1_delegation_pool_enable_partial_governance_voting">enable_partial_governance_voting</a>(pool_address);
+    }
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/staking_contract.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_contract.md
@@ -1319,6 +1319,16 @@ Store amount must be at least the min stake required for a stake pool to join th
 
 
 
+<a id="0x1_staking_contract_EINVALID_BENEFICIARY_ADDRESS"></a>
+
+Beneficiary cannot be a reserved address that cannot receive coin distributions.
+
+
+<pre><code><b>const</b> <a href="staking_contract.md#0x1_staking_contract_EINVALID_BENEFICIARY_ADDRESS">EINVALID_BENEFICIARY_ADDRESS</a>: u64 = 10;
+</code></pre>
+
+
+
 <a id="0x1_staking_contract_ENOT_STAKER_OR_OPERATOR_OR_BENEFICIARY"></a>
 
 Caller must be either the staker, operator, or beneficiary.
@@ -2283,6 +2293,12 @@ the beneficiary. An operator can set one beneficiary for staking contract pools,
     <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_operator_beneficiary_change_enabled">features::operator_beneficiary_change_enabled</a>(), std::error::invalid_state(
         <a href="staking_contract.md#0x1_staking_contract_EOPERATOR_BENEFICIARY_CHANGE_NOT_SUPPORTED">EOPERATOR_BENEFICIARY_CHANGE_NOT_SUPPORTED</a>
     ));
+    // @vm_reserved can never have an <a href="account.md#0x1_account">account</a> created for it, so it can't receive <a href="coin.md#0x1_coin">coin</a> distributions.
+    // Allowing it <b>as</b> a beneficiary would permanently brick distribution for the staking contract.
+    <b>assert</b>!(
+        new_beneficiary != @vm_reserved,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_contract.md#0x1_staking_contract_EINVALID_BENEFICIARY_ADDRESS">EINVALID_BENEFICIARY_ADDRESS</a>),
+    );
     // The beneficiay <b>address</b> of an operator is stored under the operator's <b>address</b>.
     // So, the operator does not need <b>to</b> be validated <b>with</b> respect <b>to</b> a staking pool.
     <b>let</b> operator_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(operator);

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -525,6 +525,12 @@ pub enum EntryFunctionCall {
         pool_address: AccountAddress,
     },
 
+    /// Enable partial governance voting on a delegation pool if it has not already been initialized.
+    /// This is intended for idempotent migration scripts over existing delegation pools.
+    DelegationPoolEnablePartialGovernanceVotingIfNeeded {
+        pool_address: AccountAddress,
+    },
+
     /// Evict a delegator that is not allowlisted by unlocking their entire stake.
     DelegationPoolEvictDelegator {
         delegator_address: AccountAddress,
@@ -1656,6 +1662,9 @@ impl EntryFunctionCall {
             },
             DelegationPoolEnablePartialGovernanceVoting { pool_address } => {
                 delegation_pool_enable_partial_governance_voting(pool_address)
+            },
+            DelegationPoolEnablePartialGovernanceVotingIfNeeded { pool_address } => {
+                delegation_pool_enable_partial_governance_voting_if_needed(pool_address)
             },
             DelegationPoolEvictDelegator { delegator_address } => {
                 delegation_pool_evict_delegator(delegator_address)
@@ -3493,6 +3502,25 @@ pub fn delegation_pool_enable_partial_governance_voting(
             ident_str!("delegation_pool").to_owned(),
         ),
         ident_str!("enable_partial_governance_voting").to_owned(),
+        vec![],
+        vec![bcs::to_bytes(&pool_address).unwrap()],
+    ))
+}
+
+/// Enable partial governance voting on a delegation pool if it has not already been initialized.
+/// This is intended for idempotent migration scripts over existing delegation pools.
+pub fn delegation_pool_enable_partial_governance_voting_if_needed(
+    pool_address: AccountAddress,
+) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("delegation_pool").to_owned(),
+        ),
+        ident_str!("enable_partial_governance_voting_if_needed").to_owned(),
         vec![],
         vec![bcs::to_bytes(&pool_address).unwrap()],
     ))
@@ -6722,6 +6750,20 @@ mod decoder {
         }
     }
 
+    pub fn delegation_pool_enable_partial_governance_voting_if_needed(
+        payload: &TransactionPayload,
+    ) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(
+                EntryFunctionCall::DelegationPoolEnablePartialGovernanceVotingIfNeeded {
+                    pool_address: bcs::from_bytes(script.args().get(0)?).ok()?,
+                },
+            )
+        } else {
+            None
+        }
+    }
+
     pub fn delegation_pool_evict_delegator(
         payload: &TransactionPayload,
     ) -> Option<EntryFunctionCall> {
@@ -8389,6 +8431,10 @@ static SCRIPT_FUNCTION_DECODER_MAP: once_cell::sync::Lazy<EntryFunctionDecoderMa
         map.insert(
             "delegation_pool_enable_partial_governance_voting".to_string(),
             Box::new(decoder::delegation_pool_enable_partial_governance_voting),
+        );
+        map.insert(
+            "delegation_pool_enable_partial_governance_voting_if_needed".to_string(),
+            Box::new(decoder::delegation_pool_enable_partial_governance_voting_if_needed),
         );
         map.insert(
             "delegation_pool_evict_delegator".to_string(),

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -848,6 +848,7 @@ Lifetime: transient
 
 Whether the Atomic bridge is available
 Lifetime: transient
+Deprecated in favor of <code><a href="features.md#0x1_features_ALLOW_SERIALIZED_SCRIPT_ARGS">ALLOW_SERIALIZED_SCRIPT_ARGS</a></code> as feature flag 72
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_NATIVE_BRIDGE">NATIVE_BRIDGE</a>: u64 = 72;

--- a/aptos-move/framework/move-stdlib/src/natives/bcs.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/bcs.rs
@@ -69,11 +69,15 @@ fn native_to_bytes(
     //               implement it in a more efficient way.
     let val = ref_to_val.read_ref()?;
 
+    let function_value_serialization_enabled = context
+        .get_feature_flags()
+        .is_function_value_bcs_serialization_enabled();
     let function_value_extension = context.function_value_extension();
     let max_value_nest_depth = context.max_value_nest_depth();
     let serialized_value = match ValueSerDeContext::new(max_value_nest_depth)
         .with_legacy_signer()
         .with_func_args_deserialization(&function_value_extension)
+        .with_function_value_serialization_enabled(function_value_serialization_enabled)
         .serialize(&val, &layout)?
     {
         Some(serialized_value) => serialized_value,
@@ -138,12 +142,16 @@ fn serialized_size_impl(
     let value = reference.read_ref()?;
     let ty_layout = context.type_to_type_layout(ty)?;
 
+    let function_value_serialization_enabled = context
+        .get_feature_flags()
+        .is_function_value_bcs_serialization_enabled();
     let function_value_extension = context.function_value_extension();
     let max_value_nest_depth = context.max_value_nest_depth();
     ValueSerDeContext::new(max_value_nest_depth)
         .with_legacy_signer()
         .with_func_args_deserialization(&function_value_extension)
         .with_delayed_fields_serde()
+        .with_function_value_serialization_enabled(function_value_serialization_enabled)
         .serialized_size(&value, &ty_layout)
 }
 

--- a/aptos-move/framework/table-natives/src/lib.rs
+++ b/aptos-move/framework/table-natives/src/lib.rs
@@ -366,6 +366,9 @@ fn native_add_box(
     assert_eq!(args.len(), 3);
 
     context.charge(ADD_BOX_BASE)?;
+    let function_value_serialization_enabled = context
+        .get_feature_flags()
+        .is_function_value_bcs_serialization_enabled();
     let fix_memory_double_counting =
         context.timed_feature_enabled(TimedFeatureFlag::FixTableNativesMemoryDoubleCounting);
 
@@ -379,7 +382,12 @@ fn native_add_box(
 
     let table = table_data.get_or_create_table(context, handle, &ty_args[0], &ty_args[2])?;
 
-    let key_bytes = serialize_key(&function_value_extension, &table.key_layout, &key)?;
+    let key_bytes = serialize_key(
+        &function_value_extension,
+        &table.key_layout,
+        &key,
+        function_value_serialization_enabled,
+    )?;
     let key_cost = ADD_BOX_PER_BYTE_SERIALIZED * NumBytes::new(key_bytes.len() as u64);
 
     let (gv, loaded) =
@@ -425,7 +433,11 @@ fn native_borrow_box(
     assert_eq!(args.len(), 2);
 
     context.charge(BORROW_BOX_BASE)?;
-    let fix_memory_double_counting = context.timed_feature_enabled(TimedFeatureFlag::FixTableNativesMemoryDoubleCounting);
+    let function_value_serialization_enabled = context
+        .get_feature_flags()
+        .is_function_value_bcs_serialization_enabled();
+    let fix_memory_double_counting =
+        context.timed_feature_enabled(TimedFeatureFlag::FixTableNativesMemoryDoubleCounting);
 
     let function_value_extension = context.function_value_extension();
     let table_context = context.extensions().get::<NativeTableContext>();
@@ -436,7 +448,12 @@ fn native_borrow_box(
 
     let table = table_data.get_or_create_table(context, handle, &ty_args[0], &ty_args[2])?;
 
-    let key_bytes = serialize_key(&function_value_extension, &table.key_layout, &key)?;
+    let key_bytes = serialize_key(
+        &function_value_extension,
+        &table.key_layout,
+        &key,
+        function_value_serialization_enabled,
+    )?;
     let key_cost = BORROW_BOX_PER_BYTE_SERIALIZED * NumBytes::new(key_bytes.len() as u64);
 
     let (gv, loaded) =
@@ -482,6 +499,9 @@ fn native_contains_box(
     assert_eq!(args.len(), 2);
 
     context.charge(CONTAINS_BOX_BASE)?;
+    let function_value_serialization_enabled = context
+        .get_feature_flags()
+        .is_function_value_bcs_serialization_enabled();
     let fix_memory_double_counting =
         context.timed_feature_enabled(TimedFeatureFlag::FixTableNativesMemoryDoubleCounting);
 
@@ -494,7 +514,12 @@ fn native_contains_box(
 
     let table = table_data.get_or_create_table(context, handle, &ty_args[0], &ty_args[2])?;
 
-    let key_bytes = serialize_key(&function_value_extension, &table.key_layout, &key)?;
+    let key_bytes = serialize_key(
+        &function_value_extension,
+        &table.key_layout,
+        &key,
+        function_value_serialization_enabled,
+    )?;
     let key_cost = CONTAINS_BOX_PER_BYTE_SERIALIZED * NumBytes::new(key_bytes.len() as u64);
 
     let (gv, loaded) =
@@ -534,6 +559,9 @@ fn native_remove_box(
     assert_eq!(args.len(), 2);
 
     context.charge(REMOVE_BOX_BASE)?;
+    let function_value_serialization_enabled = context
+        .get_feature_flags()
+        .is_function_value_bcs_serialization_enabled();
     let fix_memory_double_counting =
         context.timed_feature_enabled(TimedFeatureFlag::FixTableNativesMemoryDoubleCounting);
 
@@ -546,7 +574,12 @@ fn native_remove_box(
 
     let table = table_data.get_or_create_table(context, handle, &ty_args[0], &ty_args[2])?;
 
-    let key_bytes = serialize_key(&function_value_extension, &table.key_layout, &key)?;
+    let key_bytes = serialize_key(
+        &function_value_extension,
+        &table.key_layout,
+        &key,
+        function_value_serialization_enabled,
+    )?;
     let key_cost = REMOVE_BOX_PER_BYTE_SERIALIZED * NumBytes::new(key_bytes.len() as u64);
 
     let (gv, loaded) =
@@ -630,13 +663,18 @@ fn get_table_handle(table: &StructRef) -> PartialVMResult<TableHandle> {
     Ok(TableHandle(handle))
 }
 
+/// Serializes a table key. Note that the serialized bytes address the table item in global
+/// storage, and so are observable by Move code: if function value serialization is not enabled,
+/// keys containing function values cannot be used.
 fn serialize_key(
     function_value_extension: &dyn FunctionValueExtension,
     layout: &MoveTypeLayout,
     key: &Value,
+    function_value_serialization_enabled: bool,
 ) -> PartialVMResult<Vec<u8>> {
     ValueSerDeContext::new(function_value_extension.max_value_nest_depth())
         .with_func_args_deserialization(function_value_extension)
+        .with_function_value_serialization_enabled(function_value_serialization_enabled)
         .serialize(key, layout)?
         .ok_or_else(|| partial_extension_error("cannot serialize table key"))
 }

--- a/third_party/move/move-vm/types/src/value_serde.rs
+++ b/third_party/move/move-vm/types/src/value_serde.rs
@@ -105,6 +105,10 @@ pub struct ValueSerDeContext<'a> {
     pub(crate) legacy_signer: bool,
     /// Maximum allowed depth of a VM value. Enforced by serializer.
     pub(crate) max_value_nested_depth: Option<u64>,
+    /// If false, serialization of any value containing a function value fails. Only paths whose
+    /// bytes are observable by Move code need to set this, see
+    /// [ValueSerDeContext::with_function_value_serialization_enabled].
+    pub(crate) function_value_serialization_enabled: bool,
 }
 
 impl<'a> ValueSerDeContext<'a> {
@@ -115,12 +119,22 @@ impl<'a> ValueSerDeContext<'a> {
             delayed_fields_extension: None,
             legacy_signer: false,
             max_value_nested_depth,
+            function_value_serialization_enabled: true,
         }
     }
 
     /// Serialize signer with legacy format to maintain backwards compatibility.
     pub fn with_legacy_signer(mut self) -> Self {
         self.legacy_signer = true;
+        self
+    }
+
+    /// If `enabled` is false, serialization of values containing function values fails. Used to
+    /// gate the paths where the serialized bytes are observable by Move code (`bcs` natives,
+    /// table keys), so that no on-chain state can be derived from a function value format that is
+    /// not yet stable. Enabled by default, i.e. write paths are never restricted.
+    pub fn with_function_value_serialization_enabled(mut self, enabled: bool) -> Self {
+        self.function_value_serialization_enabled = enabled;
         self
     }
 
@@ -154,6 +168,7 @@ impl<'a> ValueSerDeContext<'a> {
             delayed_fields_extension: None,
             legacy_signer: self.legacy_signer,
             max_value_nested_depth: self.max_value_nested_depth,
+            function_value_serialization_enabled: self.function_value_serialization_enabled,
         }
     }
 

--- a/third_party/move/move-vm/types/src/values/function_values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/function_values_impl.rs
@@ -110,6 +110,13 @@ impl VMValueCast<Closure> for Value {
 
 impl serde::Serialize for SerializationReadyValue<'_, '_, '_, (), Closure> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        if !self.ctx.function_value_serialization_enabled {
+            // Note: the caller maps this to `Ok(None)` (or an extension error), the same as for
+            // any other value that cannot be serialized.
+            return Err(S::Error::custom(
+                "serialization of function values is not enabled",
+            ));
+        }
         let Closure(fun, captured) = self.value;
         let fun_ext = self
             .ctx

--- a/third_party/move/move-vm/types/src/values/serialization_tests.rs
+++ b/third_party/move/move-vm/types/src/values/serialization_tests.rs
@@ -11,7 +11,7 @@ mod tests {
         values::{values_impl, AbstractFunction, SerializedFunctionData, Struct, Value},
     };
     use better_any::{Tid, TidAble, TidExt};
-    use claims::{assert_err, assert_ok, assert_some};
+    use claims::{assert_err, assert_none, assert_ok, assert_some};
     use move_binary_format::errors::PartialVMResult;
     use move_core_types::{
         ability::AbilitySet,
@@ -547,6 +547,77 @@ mod tests {
                 )
             })
             .expect_err("bad size value deserialization fails");
+    }
+
+    /// Extension mock which can provide serialization data for [MockAbstractFunction].
+    fn serializing_ext_mock() -> MockFunctionValueExtension {
+        let mut ext_mock = MockFunctionValueExtension::new();
+        ext_mock
+            .expect_get_serialization_data()
+            .returning(move |af| {
+                Ok(af
+                    .downcast_ref::<MockAbstractFunction>()
+                    .expect("cast")
+                    .data
+                    .clone())
+            });
+        ext_mock
+    }
+
+    fn make_captured_closure() -> Value {
+        let fun = MockAbstractFunction::new("f", vec![], ClosureMask::new(0b1), vec![
+            MoveTypeLayout::U64,
+        ]);
+        Value::closure(Box::new(fun), vec![Value::u64(22)])
+    }
+
+    #[test]
+    fn function_value_serialization_not_enabled() {
+        let ext_mock = serializing_ext_mock();
+
+        // A function value cannot be serialized, and its size cannot be computed.
+        assert_none!(assert_ok!(ValueSerDeContext::new(None)
+            .with_func_args_deserialization(&ext_mock)
+            .with_function_value_serialization_enabled(false)
+            .serialize(&make_captured_closure(), &make_fun_layout())));
+        assert_err!(ValueSerDeContext::new(None)
+            .with_func_args_deserialization(&ext_mock)
+            .with_function_value_serialization_enabled(false)
+            .serialized_size(&make_captured_closure(), &make_fun_layout()));
+
+        // The same holds if the function value is nested inside another value.
+        let layout = MoveTypeLayout::Vector(Box::new(MoveTypeLayout::Struct(
+            MoveStructLayout::Runtime(vec![MoveTypeLayout::U8, make_fun_layout()]),
+        )));
+        let value = Value::vector_for_testing_only(vec![Value::struct_(Struct::pack(vec![
+            Value::u8(1),
+            make_captured_closure(),
+        ]))]);
+        assert_none!(assert_ok!(ValueSerDeContext::new(None)
+            .with_func_args_deserialization(&ext_mock)
+            .with_function_value_serialization_enabled(false)
+            .serialize(&value, &layout)));
+
+        // Values which do not contain function values are not affected.
+        assert_some!(assert_ok!(ValueSerDeContext::new(None)
+            .with_func_args_deserialization(&ext_mock)
+            .with_function_value_serialization_enabled(false)
+            .serialize(&Value::u64(7), &MoveTypeLayout::U64)));
+    }
+
+    #[test]
+    fn function_value_serialization_enabled_by_default() {
+        let ext_mock = serializing_ext_mock();
+
+        // Serialization of function values is only restricted if a caller asks for it, so that
+        // paths whose bytes are not observable by Move code keep working.
+        assert_some!(assert_ok!(ValueSerDeContext::new(None)
+            .with_func_args_deserialization(&ext_mock)
+            .serialize(&make_captured_closure(), &make_fun_layout())));
+        assert_some!(assert_ok!(ValueSerDeContext::new(None)
+            .with_func_args_deserialization(&ext_mock)
+            .with_function_value_serialization_enabled(true)
+            .serialize(&make_captured_closure(), &make_fun_layout())));
     }
 
     // ======================================================================================

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -149,6 +149,16 @@ pub enum FeatureFlag {
     /// compiler-generated abort codes (e.g. `UNSPECIFIED_ABORT_CODE`) against
     /// user-defined error constants whose lower bits happen to coincide.
     EXTRACT_ABORT_INFO_EXACT_MATCH = 225,
+    /// Whether BCS serialization of values containing function values is allowed to be
+    /// observed by Move code. While disabled, `bcs::to_bytes` and `bcs::serialized_size`
+    /// abort on such values, and table operations whose key contains a function value
+    /// fail. Storage writes, events and table values are unaffected.
+    ///
+    /// The V1 function value format embeds a `MoveTypeLayout` per captured argument, so
+    /// the bytes of every function value change once the format is migrated. Keeping this
+    /// disabled prevents on-chain state (hashes, table keys) from being derived from the
+    /// current bytes until the format is settled.
+    ENABLE_FUNCTION_VALUE_BCS_SERIALIZATION = 226,
 }
 
 impl FeatureFlag {
@@ -431,6 +441,10 @@ impl Features {
 
     pub fn is_distribute_transaction_fee_enabled(&self) -> bool {
         self.is_enabled(FeatureFlag::DISTRIBUTE_TRANSACTION_FEE)
+    }
+
+    pub fn is_function_value_bcs_serialization_enabled(&self) -> bool {
+        self.is_enabled(FeatureFlag::ENABLE_FUNCTION_VALUE_BCS_SERIALIZATION)
     }
 
     pub fn get_max_identifier_size(&self) -> u64 {


### PR DESCRIPTION
## Description

Adds the on-chain feature flag `ENABLE_FUNCTION_VALUE_BCS_SERIALIZATION` (226). While it is
**disabled**, the BCS bytes of a function value cannot be observed by Move code:

- `bcs::to_bytes` and `bcs::serialized_size` abort with `NFE_BCS_SERIALIZATION_FAILURE` (`0x1C5`)
  on any value containing a function value. This covers `aptos_hash::sip_hash_from_value`,
  `any::pack` / `copyable_any` and `smart_table` hashing transitively, since those are Move-level
  wrappers over `bcs::to_bytes`.
- Table operations whose **key** contains a function value fail with `VM_EXTENSION_ERROR`
  attributed to `0x1::table` (`add` / `borrow` / `borrow_mut` / `upsert` / `contains` / `remove`).

Unaffected: resource writes, events, table **values**, transaction arguments, and
deserializing / calling stored function values.

Upstream fix in aptops [aptos](https://github.com/aptos-labs/aptos-core/pull/20220)

Since `ENABLE_FUNCTION_VALUES` has never been enabled on movement mainnet, this code is not breaking.

### Why

The current (V1) function value serialization format embeds a `MoveTypeLayout` per captured
argument. Any change to that format — e.g. storing the captured arguments as a single opaque blob —
changes the BCS bytes of *every* function value. On-chain state **derived from those bytes** breaks
silently at the switch:

- a hash a contract stored or compared (`sip_hash_from_value`, and therefore `SmartTable` bucket
  assignment) no longer matches;
- a `Table` item is addressed by its serialized key, so after the switch lookups miss and the
  entry is orphaned — with no error to tell anyone.

Storage writes, events and table values are safe because those bytes are only ever read back by
the VM's own deserializer, which can be made to understand both formats. Only Move-*observable*
bytes can strand state. Keeping this flag off means no such state can be created before the format
is settled.

## How Has This Been Tested?

- `cargo test -p move-vm-types` — 70 passed. New unit tests in
  `third_party/move/move-vm/types/src/values/serialization_tests.rs`:
  - `function_value_serialization_not_enabled`: a function value fails to serialize and its size
    cannot be computed; same when nested inside a struct inside a vector; values without function
    values are unaffected.
  - `function_value_serialization_enabled_by_default`: the restriction only applies when a caller
    asks for it, so unrestricted paths keep working.
- `RUST_MIN_STACK=1073741824 cargo test -p e2e-move-tests` — **246 passed, 0 failed, 11 ignored**
  (full suite). New file
  `aptos-move/e2e-move-tests/src/tests/function_value_bcs_serialization.rs`:
  - `function_value_bcs_serialization_is_disabled_by_default`: `to_bytes` (captured, non-capturing
    and nested-in-struct-in-vector), `serialized_size` and `sip_hash_from_value` all abort
    `0x1C5`; all four function-value-keyed table operations fail at `0x1::table`; while
    `bcs::to_bytes` of an `Option` holding no function value, a resource write, a table with
    function values as *values*, an event carrying a function value, and calling a stored function
    value all succeed.
  - `function_value_bcs_serialization_works_while_enabled`: every one of the above succeeds once
    the flag is on.
  - `function_value_table_keys_are_unreachable_while_disabled`: an entry added under a function
    value key while the flag was on cannot be reached after it is turned off, and is reachable
    again once it is turned back on — the entry is not lost, just unaddressable.
- Two pre-existing tests serialize function values as a side effect and now enable the flag
  explicitly, since neither is about this restriction:
  `aggregator_v2_function_values::test_function_value_captures_aggregator` (via `bcs::to_bytes`,
  it asserts the *aggregator* cannot be captured and serialized) and
  `any::test_any_with_function_values` (via `any::pack`). These two are the entire default-deny
  blast radius in the suite.
- Move transactional test suites are unaffected: they use the pure
  `third_party/move/move-stdlib` `bcs` natives, which do not read the feature, and the knob
  defaults to enabled.
- `cargo clippy` on the five touched crates: no new warnings.

## Key Areas to Review

- **The default-deny decision** (`types/src/on_chain_config/aptos_features.rs`): the flag is not in
  `default_features()`, so this changes behaviour on an already-running network at upgrade time.
  Please confirm that is what we want, or ask for the one-line change to default-allow.
- **Scope of the gated paths** (`bcs.rs`, `table-natives/src/lib.rs`): the claim is that `bcs::to_bytes`,
  `bcs::serialized_size` and table keys are the only ways Move code can observe function value
  bytes. Worth a second pair of eyes on anything I may have missed. Deliberately left open:
  resource writes, events, table values, deserialization.
- **Enforcement point** (`function_values_impl.rs`): putting the check in the closure serializer is
  what makes nesting work; a check at the native boundary would need to walk the value instead.
- **Error shapes**: a Move abort (`0x1C5`) from the `bcs` natives vs. an execution failure
  attributed to `0x1::table` for keys. Both reuse existing failure paths, but they are
  Move-visible behaviour and worth confirming.
- **`table::borrow` is gated too**, so `borrow_mut` and `upsert` on a function-value key fail as
  well — slightly wider than "hashing and key insertion".

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?

- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (specify): `aptos-release-builder` feature flag mapping

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/movement-network/codesmith/aptos-core/pr/420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790434212&installation_model_id=17568&pr_number=420&repository=movement-network%2Faptos-core&return_to=https%3A%2F%2Fgithub.com%2Fmovement-network%2Faptos-core%2Fpull%2F420&signature=9833c39ad67c891d870f238acdbff718b895e763625470b1f52fc72017069fef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->