### PR TITLE
fix: remove global waypoint signature-verification bypass from the live consensus path

### DIFF
--- a/aptos-node/src/storage.rs
+++ b/aptos-node/src/storage.rs
@@ -11,7 +11,7 @@ use aptos_indexer_grpc_table_info::internal_indexer_db_service::InternalIndexerD
 use aptos_logger::{debug, info};
 use aptos_storage_interface::{DbReader, DbReaderWriter};
 use aptos_types::{
-    ledger_info::{set_waypoint_version, LedgerInfoWithSignatures},
+    ledger_info::LedgerInfoWithSignatures,
     transaction::Version,
     waypoint::Waypoint,
 };
@@ -198,7 +198,6 @@ pub fn initialize_database_and_checkpoints(
     );
 
     let waypoint = node_config.base.waypoint.waypoint();
-    set_waypoint_version(waypoint.version());
     Ok((
         db_rw,
         backup_service,

--- a/consensus/consensus-types/tests/ledger_info_waypoint_regression.rs
+++ b/consensus/consensus-types/tests/ledger_info_waypoint_regression.rs
@@ -1,0 +1,125 @@
+// Regression tests for the waypoint verification bypass (audit finding C1).
+//
+// Previously, `LedgerInfoWithSignatures::verify_signatures` returned `Ok(())`
+// for any ledger info with `version <= waypoint_version` (a process-global set
+// at node startup). Because decoupled execution gives every ordered QC and
+// CommitDecision `version == 0`, the bypass covered ALL live consensus
+// messages: forged messages with empty aggregate signatures were accepted.
+//
+// These tests pin the fixed behavior: signature verification always runs.
+
+use aptos_consensus_types::{
+    pipeline::commit_decision::CommitDecision, quorum_cert::QuorumCert, vote_data::VoteData,
+};
+use aptos_crypto::{
+    hash::{CryptoHash, ACCUMULATOR_PLACEHOLDER_HASH},
+    HashValue,
+};
+use aptos_types::{
+    aggregate_signature::AggregateSignature,
+    block_info::BlockInfo,
+    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    validator_signer::ValidatorSigner,
+    validator_verifier::{ValidatorConsensusInfo, ValidatorVerifier},
+};
+
+fn seven_validator_setup() -> (Vec<ValidatorSigner>, ValidatorVerifier) {
+    let signers: Vec<ValidatorSigner> = (0..7).map(|i| ValidatorSigner::random([i; 32])).collect();
+    let infos: Vec<_> = signers
+        .iter()
+        .map(|s| ValidatorConsensusInfo::new(s.author(), s.public_key(), 1))
+        .collect();
+    (
+        signers,
+        ValidatorVerifier::new_with_quorum_voting_power(infos, 5).unwrap(),
+    )
+}
+
+fn block_info(round: u64, version: u64) -> BlockInfo {
+    BlockInfo::new(
+        1,                   // epoch
+        round,
+        HashValue::random(), // id
+        HashValue::random(), // executed_state_id
+        version,
+        12345,
+        None,
+    )
+}
+
+#[test]
+fn forged_commit_decision_with_empty_signature_is_rejected() {
+    let (_, verifier) = seven_validator_setup();
+
+    // The exact forgery from the C1 PoC: a CommitDecision carrying an EMPTY
+    // aggregate signature over a version-0 ledger info (the shape of every
+    // commit decision under decoupled execution).
+    let forged = CommitDecision::new(LedgerInfoWithSignatures::new(
+        LedgerInfo::new(block_info(10, 0), HashValue::zero()),
+        AggregateSignature::empty(),
+    ));
+    assert!(
+        forged.verify(&verifier).is_err(),
+        "a CommitDecision with no valid signatures must never verify"
+    );
+}
+
+#[test]
+fn forged_version_zero_quorum_cert_with_empty_signature_is_rejected() {
+    let (_, verifier) = seven_validator_setup();
+
+    // A version-0 ordered QC — the exact shape produced by decoupled
+    // execution — with an empty aggregate signature. VoteData must be
+    // well-formed (QuorumCert::verify checks consensus_data_hash ==
+    // vote_data.hash() and vote_data.verify()).
+    let parent = BlockInfo::new(
+        1,
+        10,
+        HashValue::random(),
+        *ACCUMULATOR_PLACEHOLDER_HASH,
+        0,
+        12345,
+        None,
+    );
+    let proposed = BlockInfo::new(
+        1,
+        11,
+        HashValue::random(),
+        *ACCUMULATOR_PLACEHOLDER_HASH,
+        0,
+        12346,
+        None,
+    );
+    let vote_data = VoteData::new(proposed, parent.clone());
+    let qc_ledger_info = LedgerInfoWithSignatures::new(
+        LedgerInfo::new(parent, vote_data.hash()),
+        AggregateSignature::empty(),
+    );
+    let qc = QuorumCert::new(vote_data, qc_ledger_info);
+    assert!(
+        qc.verify(&verifier).is_err(),
+        "an ordered QC with no valid signatures must never verify"
+    );
+}
+
+#[test]
+fn honestly_signed_commit_decision_still_verifies() {
+    // Control: legitimate quorum-signed messages must keep passing.
+    let (signers, verifier) = seven_validator_setup();
+
+    let ledger_info = LedgerInfo::new(block_info(10, 0), HashValue::zero());
+    // 5 of 7 voting power = quorum
+    let signatures: Vec<_> = signers
+        .iter()
+        .take(5)
+        .map(|s| (s.author(), s.sign(&ledger_info).unwrap()))
+        .collect();
+    let aggregate = verifier
+        .aggregate_signatures(signatures.iter().map(|(a, s)| (a, s)))
+        .unwrap();
+    let decision = CommitDecision::new(LedgerInfoWithSignatures::new(ledger_info, aggregate));
+    assert!(
+        decision.verify(&verifier).is_ok(),
+        "a quorum-signed CommitDecision must verify"
+    );
+}

--- a/state-sync/inter-component/event-notifications/src/lib.rs
+++ b/state-sync/inter-component/event-notifications/src/lib.rs
@@ -13,7 +13,6 @@ use aptos_storage_interface::{
 use aptos_types::{
     contract_event::ContractEvent,
     event::EventKey,
-    ledger_info::get_waypoint_version,
     on_chain_config::{
         ConfigurationResource, OnChainConfig, OnChainConfigPayload, OnChainConfigProvider,
     },
@@ -415,11 +414,11 @@ pub struct DbBackedOnChainConfig {
 }
 
 impl DbBackedOnChainConfig {
-    pub fn new(reader: Arc<dyn DbReader>, mut version: Version) -> Self {
-        let waypoint_version = get_waypoint_version().expect("Waypoint version is missing");
-        if version < waypoint_version {
-            version = waypoint_version as Version;
-        }
+    /// `version` must already be clamped by the caller to the DB's first
+    /// available version (see `read_on_chain_configs`), so that reads never
+    /// target state the node does not hold (e.g. pre-waypoint history on a
+    /// fast-synced node). No waypoint-based adjustment happens here.
+    pub fn new(reader: Arc<dyn DbReader>, version: Version) -> Self {
         Self { reader, version }
     }
 }

--- a/state-sync/inter-component/event-notifications/src/tests.rs
+++ b/state-sync/inter-component/event-notifications/src/tests.rs
@@ -17,7 +17,6 @@ use aptos_types::{
     account_config::NEW_EPOCH_EVENT_V2_MOVE_TYPE_TAG,
     contract_event::ContractEvent,
     event::EventKey,
-    ledger_info::set_waypoint_version,
     on_chain_config,
     on_chain_config::OnChainConfig,
     transaction::{Transaction, Version, WriteSetPayload},
@@ -569,9 +568,7 @@ fn create_database() -> Arc<RwLock<DbReaderWriter>> {
         &db_rw,
         &genesis_txn
     ));
-
-    // Initialize the global waypoint version
-    set_waypoint_version(waypoint.version());
+    let _ = waypoint;
 
     Arc::new(RwLock::new(db_rw))
 }

--- a/state-sync/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/bootstrapper.rs
@@ -75,6 +75,13 @@ impl VerifiedEpochStates {
         self.fetched_epoch_ending_ledger_infos
     }
 
+    /// Returns the latest trusted epoch state. Pre-waypoint (pre-migration)
+    /// ledger infos never update this — see `update_verified_epoch_states`.
+    #[cfg(test)]
+    pub fn latest_epoch_state(&self) -> &EpochState {
+        &self.latest_epoch_state
+    }
+
     /// Sets `fetched_epoch_ending_ledger_infos` to true
     pub fn set_fetched_epoch_ending_ledger_infos(&mut self) {
         self.fetched_epoch_ending_ledger_infos = true;
@@ -140,7 +147,18 @@ impl VerifiedEpochStates {
             return Ok(());
         }
 
-        // For non-waypoint epochs: verify the ledger info against the latest epoch state
+        // Ledger infos before the waypoint predate the L1 migration and are
+        // not signature-verifiable (different historical format). Accept them
+        // as unverified archive data: retain them for chunk-commit lookups,
+        // but never install their next_epoch_state as trusted, and never let
+        // them reach signature verification or the waypoint ratchet below.
+        if ledger_info.version() < waypoint.version() {
+            self.highest_fetched_epoch_ending_version = ledger_info.version();
+            self.insert_new_epoch_ending_ledger_info(epoch_ending_ledger_info.clone())?;
+            return Ok(());
+        }
+
+        // For post-waypoint epochs: verify the ledger info against the latest epoch state
         self.latest_epoch_state
             .verify(epoch_ending_ledger_info)
             .map_err(|error| {

--- a/state-sync/state-sync-driver/src/tests/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/tests/bootstrapper.rs
@@ -29,9 +29,16 @@ use aptos_data_streaming_service::{
 };
 use aptos_time_service::TimeService;
 use aptos_types::{
+    aggregate_signature::AggregateSignature,
+    block_info::BlockInfo,
+    epoch_state::EpochState,
+    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     transaction::{TransactionOutputListWithProof, Version},
+    validator_signer::ValidatorSigner,
+    validator_verifier::{ValidatorConsensusInfo, ValidatorVerifier},
     waypoint::Waypoint,
 };
+use aptos_crypto::hash::HashValue;
 use claims::{assert_matches, assert_none, assert_ok};
 use futures::{channel::{mpsc, oneshot}, FutureExt, SinkExt};
 use mockall::{predicate::eq, Sequence};
@@ -1590,6 +1597,119 @@ async fn test_waypoint_satisfiable() {
         .await
         .unwrap_err();
     assert_matches!(error, Error::UnsatisfiableWaypoint(_));
+}
+
+/// Regression test for audit findings C1/H1 (waypoint verification bypass).
+/// A forged pre-waypoint epoch-ending ledger info (empty aggregate
+/// signature, attacker-chosen `next_epoch_state`) must still be ACCEPTED as
+/// unverified archive data (pre-migration history is not
+/// signature-verifiable), but must NOT install its `next_epoch_state` as
+/// trusted.
+#[test]
+fn test_pre_waypoint_ledger_info_accepted_as_unverified_archive_only() {
+    // Create a bootstrapper for a victim node (trusted epoch state at epoch 0)
+    let driver_configuration = create_full_node_driver_configuration();
+    let (mut bootstrapper, _) =
+        create_bootstrapper(driver_configuration, MockStreamingClient::new(), None, false);
+
+    // Waypoint anchored at version 1000
+    let waypoint_ledger_info = create_random_epoch_ending_ledger_info(1000, 0);
+    let waypoint = Waypoint::new_any(waypoint_ledger_info.ledger_info());
+
+    let verified_epoch_states = bootstrapper.get_verified_epoch_states();
+    assert_eq!(verified_epoch_states.latest_epoch_state().epoch, 0);
+
+    // The forgery: version 500 (< waypoint), epoch 0, `next_epoch_state` for
+    // epoch 1, EMPTY aggregate signature
+    let forged = create_random_epoch_ending_ledger_info(500, 0);
+    verified_epoch_states
+        .update_verified_epoch_states(&forged, &waypoint)
+        .expect("pre-waypoint archive data must still be accepted");
+
+    // It is retained for chunk-commit lookups...
+    assert!(verified_epoch_states
+        .all_epoch_ending_ledger_infos()
+        .contains(&forged));
+
+    // ...but its `next_epoch_state` (epoch 1) was NOT installed as trusted
+    assert_eq!(verified_epoch_states.latest_epoch_state().epoch, 0);
+}
+
+/// Regression test for the H1/F2 attack chain: the attacker forges a
+/// pre-waypoint epoch-ending ledger info whose `next_epoch_state` contains
+/// the ATTACKER'S validator set (accepted via the bypass), then signs a
+/// post-waypoint ledger info with the attacker's OWN keys so it verifies
+/// against the installed fake epoch state — poisoning trust and reaching
+/// the `verify_waypoint` panic. Post-fix, the pre-waypoint ledger info
+/// never installs its `next_epoch_state`, so the post-waypoint forgery
+/// fails the epoch continuity check.
+#[test]
+fn test_forged_pre_waypoint_chain_cannot_escalate_to_post_waypoint_forgery() {
+    let driver_configuration = create_full_node_driver_configuration();
+    let (mut bootstrapper, _) =
+        create_bootstrapper(driver_configuration, MockStreamingClient::new(), None, false);
+
+    let waypoint_ledger_info = create_random_epoch_ending_ledger_info(1000, 0);
+    let waypoint = Waypoint::new_any(waypoint_ledger_info.ledger_info());
+
+    let verified_epoch_states = bootstrapper.get_verified_epoch_states();
+
+    // Step 1: forged pre-waypoint ledger info carrying the attacker's
+    // validator set, with an EMPTY aggregate signature
+    let attacker_signer = ValidatorSigner::random([42; 32]);
+    let make_attacker_verifier = || {
+        ValidatorVerifier::new(vec![ValidatorConsensusInfo::new(
+            attacker_signer.author(),
+            attacker_signer.public_key(),
+            1,
+        )])
+    };
+    let forged_pre = LedgerInfoWithSignatures::new(
+        LedgerInfo::new(
+            BlockInfo::new(
+                0, // epoch matches the victim's trusted epoch
+                0,
+                HashValue::zero(),
+                HashValue::random(),
+                500, // version < waypoint
+                0,
+                Some(EpochState::new(1, make_attacker_verifier())),
+            ),
+            HashValue::random(),
+        ),
+        AggregateSignature::empty(),
+    );
+    verified_epoch_states
+        .update_verified_epoch_states(&forged_pre, &waypoint)
+        .expect("pre-waypoint archive data must still be accepted");
+
+    // Step 2: post-waypoint ledger info signed by the attacker's OWN key.
+    // This only verifies if step 1 installed the attacker's validator set.
+    let post_waypoint_ledger_info = LedgerInfo::new(
+        BlockInfo::new(
+            1, // epoch continues the forged chain
+            0,
+            HashValue::zero(),
+            HashValue::random(),
+            1500, // version > waypoint
+            0,
+            Some(EpochState::new(2, make_attacker_verifier())),
+        ),
+        HashValue::random(),
+    );
+    let attacker_sig = attacker_signer.sign(&post_waypoint_ledger_info).unwrap();
+    let attacker_aggregate = make_attacker_verifier()
+        .aggregate_signatures([(attacker_signer.author(), attacker_sig)].iter().map(|(a, s)| (a, s)))
+        .unwrap();
+    let forged_post =
+        LedgerInfoWithSignatures::new(post_waypoint_ledger_info, attacker_aggregate);
+
+    assert!(
+        verified_epoch_states
+            .update_verified_epoch_states(&forged_post, &waypoint)
+            .is_err(),
+        "post-waypoint forgery must fail: the trusted epoch state never left epoch 0"
+    );
 }
 
 /// Creates a bootstrapper for testing

--- a/state-sync/state-sync-driver/src/tests/driver.rs
+++ b/state-sync/state-sync-driver/src/tests/driver.rs
@@ -31,7 +31,6 @@ use aptos_storage_service_notifications::StorageServiceNotificationListener;
 use aptos_time_service::TimeService;
 use aptos_types::{
     event::EventKey,
-    ledger_info::set_waypoint_version,
     transaction::{Transaction, WriteSetPayload},
     waypoint::Waypoint,
 };
@@ -345,9 +344,6 @@ async fn create_driver_for_tests_with_waypoint(
     // Get the actual waypoint from the bootstrapped database
     let genesis_ledger_info = db_rw.reader.get_latest_ledger_info().unwrap();
     let waypoint = Waypoint::new_any(genesis_ledger_info.ledger_info());
-
-    // Set the global waypoint version for event notifications
-    set_waypoint_version(waypoint.version());
 
     create_driver_for_tests(node_config, waypoint, event_key_subscriptions).await
 }

--- a/state-sync/state-sync-driver/src/tests/driver_factory.rs
+++ b/state-sync/state-sync-driver/src/tests/driver_factory.rs
@@ -24,7 +24,6 @@ use aptos_storage_interface::DbReaderWriter;
 use aptos_storage_service_client::StorageServiceClient;
 use aptos_temppath::TempPath;
 use aptos_time_service::TimeService;
-use aptos_types::ledger_info::set_waypoint_version;
 use aptos_vm::aptos_vm::AptosVMBlockExecutor;
 use futures::{FutureExt, StreamExt};
 use std::{collections::HashMap, sync::Arc};
@@ -54,9 +53,6 @@ fn test_new_initialized_configs() {
     // Get the actual waypoint from the bootstrapped database
     let genesis_ledger_info = db_rw.reader.get_latest_ledger_info().unwrap();
     let waypoint = aptos_types::waypoint::Waypoint::new_any(genesis_ledger_info.ledger_info());
-
-    // Set the global waypoint version for event notifications
-    set_waypoint_version(waypoint.version());
 
     // Create mempool and consensus notifiers
     let (mempool_notifier, _) = new_mempool_notifier_listener_pair(100);

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -28,22 +28,9 @@ use std::{
     ops::{Deref, DerefMut},
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc, OnceLock,
+        Arc,
     },
 };
-
-/// Global waypoint version storage for bypassing verification of historical data
-static WAYPOINT_VERSION: OnceLock<Version> = OnceLock::new();
-
-/// Initialize the waypoint version (should be called once during node startup)
-pub fn set_waypoint_version(version: Version) {
-    let _ = WAYPOINT_VERSION.set(version);
-}
-
-/// Get the waypoint version if it has been set
-pub fn get_waypoint_version() -> Option<Version> {
-    WAYPOINT_VERSION.get().copied()
-}
 
 /// This structure serves a dual purpose.
 ///
@@ -318,13 +305,11 @@ impl LedgerInfoWithV0 {
         &self,
         validator: &ValidatorVerifier,
     ) -> ::std::result::Result<(), VerifyError> {
-        // Check if this LedgerInfo is before the waypoint version
-        if let Some(waypoint_version) = get_waypoint_version() {
-            if self.ledger_info().version() <= waypoint_version {
-                return Ok(());
-            }
-        }
-
+        // Signatures are always verified. Pre-waypoint (pre-migration) ledger
+        // infos are not signature-verifiable and are handled explicitly by the
+        // state-sync bootstrapper's historical path instead of being
+        // short-circuited here — this shared primitive is on the live
+        // consensus path (quorum certs, commit decisions, epoch changes).
         validator.verify_multi_signatures(self.ledger_info(), &self.signatures)
     }
 


### PR DESCRIPTION

> Supersedes the approach discussed in #376. Findings C1/H1/F2 of the m1 security review.
> Code permalinks are pinned to the pre-fix base [`95b5a3b`](https://github.com/movement-network/aptos-core/commit/95b5a3bfa217c6ed1920485225afb4583990c7f2) and the fix commit [`19e104a`](https://github.com/movement-network/aptos-core/commit/19e104ad8b87fee4350511c05512f72d1c32a420).

## Description

### Summary

`LedgerInfoWithSignatures::verify_signatures` contained a process-global short-circuit: any ledger info with `version <= waypoint_version` was accepted **without verifying its aggregate signature** ([pre-fix code](https://github.com/movement-network/aptos-core/blob/95b5a3bfa217c6ed1920485225afb4583990c7f2/types/src/ledger_info.rs#L317-L329)). The bypass was added during the L1-migration cutover ([`d66d3b2`](https://github.com/movement-network/aptos-core/commit/d66d3b2ae8)) to tolerate pre-migration history, but it lives in the shared verification primitive used by **both** state sync and live consensus.

Because decoupled execution assigns `version == 0` to every ordered QC — and nothing on the receive path enforces what `version` a CommitDecision claims — the bypass window (`version <= waypoint_version`) is reachable from **live consensus traffic**, not just pre-migration history. This PR removes the global bypass and handles pre-waypoint data explicitly inside the state-sync bootstrapper, where such tolerance actually belongs.

### The bug

`types/src/ledger_info.rs` (before — [static + setter/getter](https://github.com/movement-network/aptos-core/blob/95b5a3bfa217c6ed1920485225afb4583990c7f2/types/src/ledger_info.rs#L36-L47), [`verify_signatures`](https://github.com/movement-network/aptos-core/blob/95b5a3bfa217c6ed1920485225afb4583990c7f2/types/src/ledger_info.rs#L317-L329)):

```rust
static WAYPOINT_VERSION: OnceLock<Version> = OnceLock::new();

pub fn set_waypoint_version(version: Version) { ... }   // called unconditionally
                                                        // at node startup
pub fn verify_signatures(&self, validator: &ValidatorVerifier) -> Result<(), VerifyError> {
    // Check if this LedgerInfo is before the waypoint version
    if let Some(waypoint_version) = get_waypoint_version() {
        if self.ledger_info().version() <= waypoint_version {
            return Ok(());        // <-- no signature check at all
        }
    }
    validator.verify_multi_signatures(self.ledger_info(), &self.signatures)
}
```

The global is set from the configured base waypoint at every node startup ([`aptos-node/src/storage.rs:201`](https://github.com/movement-network/aptos-core/blob/95b5a3bfa217c6ed1920485225afb4583990c7f2/aptos-node/src/storage.rs#L201)). On Movement networks the waypoint version is the migration cutover point (currently ~195M), so `version <= waypoint_version` is true for essentially everything a node ever sees — including, critically, **live** consensus messages:

Decoupled execution is hardcoded on ([`consensus_config.rs:231-233`](https://github.com/movement-network/aptos-core/blob/95b5a3bfa217c6ed1920485225afb4583990c7f2/types/src/on_chain_config/consensus_config.rs#L231-L233)), and every ordered vote/QC is built with `version == 0` ([`vote_proposal.rs:61-70`](https://github.com/movement-network/aptos-core/blob/95b5a3bfa217c6ed1920485225afb4583990c7f2/consensus/consensus-types/src/vote_proposal.rs#L61-L70)):

```rust
pub fn decoupled_execution(&self) -> bool {
    true
}

fn vote_data_ordering_only(&self) -> VoteData {
    VoteData::new(
        self.block().gen_block_info(
            *ACCUMULATOR_PLACEHOLDER_HASH,
            0,                       // <-- version is ALWAYS 0
            self.next_epoch_state().cloned(),
        ),
        ...
    )
}
```

So every ordered QC carries `version == 0` and skips signature verification entirely (selected in [`gen_vote_data`](https://github.com/movement-network/aptos-core/blob/95b5a3bfa217c6ed1920485225afb4583990c7f2/consensus/consensus-types/src/vote_proposal.rs#L88-L91)).

Honest `CommitDecision`s are different: their `commit_info` is built from the *executed* block's [`block_info()`](https://github.com/movement-network/aptos-core/blob/95b5a3bfa217c6ed1920485225afb4583990c7f2/consensus/consensus-types/src/pipelined_block.rs#L486-L492), which carries the real ledger version computed by the executor ([`first_version` accumulated from the parent block](https://github.com/movement-network/aptos-core/blob/95b5a3bfa217c6ed1920485225afb4583990c7f2/execution/executor/src/block_executor/mod.rs#L231)). But nothing enforces that on the receive path — a **forged** `CommitDecision` with attacker-chosen `version == 0` rides the same bypass (this is Mode 1 below).

`verify_signatures` callers on the live path include `QuorumCert::verify`, `CommitDecision::verify`, `WrappedLedgerInfo::verify`, `EpochState::verify` (sync-info), safety rules, DAG sync, and quorum-store batch requests.

### Attacker modes

**Mode 1 — single validator halts the chain (liveness).**
A validator (membership currently requires only 100k MOVE stake — there is no on-chain `AllowedValidators` allowlist) broadcasts a forged `CommitDecision` for an in-flight block:

```rust
let forged_decision = CommitMessage::Decision(CommitDecision::new(
    LedgerInfoWithSignatures::new(
        LedgerInfo::new(forged_block_info, HashValue::zero()),
        AggregateSignature::empty(),        // NO signatures
    ),
));
```

- same block id → peers route it to their in-flight buffer item;
- fabricated `executed_state_id` (a random hash bypasses the `is_ordered_only` placeholder guard);
- `version == 0` → falls into the bypass window, signature check skipped.

The victim accepts it, and the fabricated `executed_state_id` mismatches local execution at `buffer_item.rs`'s `assert_eq!(commit_info, *commit_proof.commit_info())` ([permalink](https://github.com/movement-network/aptos-core/blob/95b5a3bfa217c6ed1920485225afb4583990c7f2/consensus/src/pipeline/buffer_item.rs#L280)) → **panic**. The process crashes; after restart it state-syncs, receives the forged decision again, and crashes again. One malicious validator keeps the network in a crash loop. (PoC: `poc_c1_*` tests in the security review; the same behavior is pinned by the regression tests in this PR.)

**Mode 2 — any state-sync peer forges validator-set history (integrity).**
No validator membership needed. A single malicious sync peer serves forged pre-waypoint epoch-ending ledger infos (empty signatures, attacker-chosen `next_epoch_state`) to a bootstrapping node. The bypass accepts them inside [`update_verified_epoch_states`](https://github.com/movement-network/aptos-core/blob/95b5a3bfa217c6ed1920485225afb4583990c7f2/state-sync/state-sync-driver/src/bootstrapper.rs#L100), the attacker's validator set is installed as the trusted epoch state, and during fast sync the forged ledger infos are persisted via `finalize_state_snapshot` ([`aptosdb_writer.rs:97`](https://github.com/movement-network/aptos-core/blob/95b5a3bfa217c6ed1920485225afb4583990c7f2/storage/aptosdb/src/db/include/aptosdb_writer.rs#L97)) → `save_ledger_infos` with no verification — then **served onward to other waypoint-trusting peers**, propagating falsified epoch/validator-set history network-wide and into backups.

**Mode 3 — any state-sync peer crash-loops a bootstrapping node (availability).**
After Mode 2's forged chain installs the attacker's validator set, the attacker signs a post-waypoint ledger info with their *own* keys — it verifies against the installed fake epoch state — and `verify_waypoint` panics on `ledger_info_version > waypoint_version` ([`bootstrapper.rs:172-189`](https://github.com/movement-network/aptos-core/blob/95b5a3bfa217c6ed1920485225afb4583990c7f2/state-sync/state-sync-driver/src/bootstrapper.rs#L172-L189)). Unauthenticated remote crash loop with a correct config; in upstream this panic was only reachable via operator misconfiguration.

**Impact boundary (unchanged by this PR):** none of these forge *state* — fabricated execution results fail the chunk/execution comparison and cannot be persisted as committed state, and nothing at/above the waypoint can be signed without real quorum keys. The damage is liveness (chain halt / crash loops) and history integrity (forged validator-set history persisted and gossiped).

### The fix

**1. `verify_signatures` always verifies** ([`types/src/ledger_info.rs:304-314`](https://github.com/movement-network/aptos-core/blob/19e104ad8b87fee4350511c05512f72d1c32a420/types/src/ledger_info.rs#L304-L314)). The global `WAYPOINT_VERSION`, its setter/getter, and the startup call in `aptos-node/src/storage.rs` are removed:

```rust
pub fn verify_signatures(&self, validator: &ValidatorVerifier) -> Result<(), VerifyError> {
    // Signatures are always verified. Pre-waypoint (pre-migration) ledger
    // infos are handled explicitly by the state-sync bootstrapper.
    validator.verify_multi_signatures(self.ledger_info(), &self.signatures)
}
```

**2. Pre-waypoint tolerance becomes an explicit, local policy** ([`state-sync/state-sync-driver/src/bootstrapper.rs:150-159`](https://github.com/movement-network/aptos-core/blob/19e104ad8b87fee4350511c05512f72d1c32a420/state-sync/state-sync-driver/src/bootstrapper.rs#L150-L159)):

```rust
// Ledger infos before the waypoint predate the L1 migration and are
// not signature-verifiable (different historical format). Accept them
// as unverified archive data: retain them for chunk-commit lookups,
// but never install their next_epoch_state as trusted, and never let
// them reach signature verification or the waypoint ratchet below.
if ledger_info.version() < waypoint.version() {
    self.highest_fetched_epoch_ending_version = ledger_info.version();
    self.insert_new_epoch_ending_ledger_info(epoch_ending_ledger_info.clone())?;
    return Ok(());
}

// version == waypoint.version(): hash-verified fast path (unchanged, above)
// version > waypoint.version(): full signature verification (now real)
```

This kills Modes 2 and 3: forged pre-waypoint ledger infos are still *stored* (archive sync keeps working — the reason #376's bare removal had to be reverted), but they no longer poison the trusted epoch state, so the post-waypoint forgery in Mode 3 fails the epoch continuity check instead of reaching the panic.

**3. `event-notifications`** ([`DbBackedOnChainConfig::new`](https://github.com/movement-network/aptos-core/blob/19e104ad8b87fee4350511c05512f72d1c32a420/state-sync/inter-component/event-notifications/src/lib.rs#L416-L424)): the waypoint-based clamp ([pre-fix code](https://github.com/movement-network/aptos-core/blob/95b5a3bfa217c6ed1920485225afb4583990c7f2/state-sync/inter-component/event-notifications/src/lib.rs#L419-L421), and its `.expect("Waypoint version is missing")` panic) is removed; the sole caller ([`read_on_chain_configs`](https://github.com/movement-network/aptos-core/blob/19e104ad8b87fee4350511c05512f72d1c32a420/state-sync/inter-component/event-notifications/src/lib.rs#L282)) already clamps reads to the DB's first available version.

### Why not #376's approach

#376 removed the short-circuit with no replacement, which broke archive/full-history sync (pre-waypoint L2-era ledger infos can never verify), and was closed with "gate pre-waypoint state access separately" as the intended follow-up. This PR is that follow-up: the bypass is gone from the shared primitive, and the tolerance exists only as an explicit branch in the bootstrapper's historical path. Note that #376's impact assessment ("not reachable: live-consensus takeover") missed the `version == 0` fact above — the bypass does cover live consensus.

### What this does NOT change

- Historical transaction/state availability: full-history and archive sync keep working; pre-waypoint data is still fetched and stored.
- The waypoint remains the trust anchor for the fork point (hash-verified).
- Post-waypoint verification is byte-for-byte upstream behavior.
- Not a consensus-rule change: honest messages are signed by real quorums and verify exactly as before. Safe for rolling upgrade; no hard fork, no epoch alignment.

### Out of scope (follow-ups)

- Backup/restore `--trust-waypoint` degrades verification the same way (finding H2) — separate fix in `backup-cli`.
- Pre-waypoint epoch history remains *unverifiable* by design; if authenticity of that history is required (explorers/indexers), the migration tooling should emit a checkpoint table (`epoch -> epoch-ending LI hash`) for the bootstrapper to hash-check against.
- Chain-id gating of mainnet safety gates: #391.

## How Has This Been Tested?

New regression tests (included):

- [`consensus/consensus-types/tests/ledger_info_waypoint_regression.rs`](https://github.com/movement-network/aptos-core/blob/19e104ad8b87fee4350511c05512f72d1c32a420/consensus/consensus-types/tests/ledger_info_waypoint_regression.rs)
  - forged `CommitDecision` with an empty aggregate signature (version 0) is **rejected** ([test](https://github.com/movement-network/aptos-core/blob/19e104ad8b87fee4350511c05512f72d1c32a420/consensus/consensus-types/tests/ledger_info_waypoint_regression.rs#L51));
  - forged version-0 ordered `QuorumCert` with an empty aggregate signature is **rejected** ([test](https://github.com/movement-network/aptos-core/blob/19e104ad8b87fee4350511c05512f72d1c32a420/consensus/consensus-types/tests/ledger_info_waypoint_regression.rs#L68));
  - control: an honestly quorum-signed `CommitDecision` still verifies ([test](https://github.com/movement-network/aptos-core/blob/19e104ad8b87fee4350511c05512f72d1c32a420/consensus/consensus-types/tests/ledger_info_waypoint_regression.rs#L106)).
- [`state-sync/state-sync-driver/src/tests/bootstrapper.rs`](https://github.com/movement-network/aptos-core/blob/19e104ad8b87fee4350511c05512f72d1c32a420/state-sync/state-sync-driver/src/tests/bootstrapper.rs)
  - [`test_pre_waypoint_ledger_info_accepted_as_unverified_archive_only`](https://github.com/movement-network/aptos-core/blob/19e104ad8b87fee4350511c05512f72d1c32a420/state-sync/state-sync-driver/src/tests/bootstrapper.rs#L1609): forged pre-waypoint LI is accepted as archive data but its `next_epoch_state` is NOT installed as trusted;
  - [`test_forged_pre_waypoint_chain_cannot_escalate_to_post_waypoint_forgery`](https://github.com/movement-network/aptos-core/blob/19e104ad8b87fee4350511c05512f72d1c32a420/state-sync/state-sync-driver/src/tests/bootstrapper.rs#L1647): the Mode-2/3 chain (forged pre-W install → attacker-signed post-W LI) now fails.

Also run: `cargo check -p aptos-types -p aptos-event-notifications -p aptos-state-sync-driver -p aptos-consensus-types -p aptos-node`; existing state-sync-driver and event-notifications test suites (previously dependent on the removed global, updated in this PR).

The original PoC tests demonstrating the bypass (`poc_c1_bypass_with_waypoint`, `poc_c1_control_no_waypoint`, `test_poc_c1_forged_commit_decision_panics_executed_item`) pass on unfixed `m1` and are inverted by the regression tests here.

## Key Areas to Review

- [`bootstrapper.rs:150-159`](https://github.com/movement-network/aptos-core/blob/19e104ad8b87fee4350511c05512f72d1c32a420/state-sync/state-sync-driver/src/bootstrapper.rs#L150-L159) — the new pre-waypoint branch: confirm no consumer required pre-waypoint `next_epoch_state` to be ratcheted as trusted before the waypoint LI arrives (the waypoint fast-path installs the correct state; chunk-commit verification compares against locally computed values).
- [`event-notifications`](https://github.com/movement-network/aptos-core/blob/19e104ad8b87fee4350511c05512f72d1c32a420/state-sync/inter-component/event-notifications/src/lib.rs#L416-L424) — the removed clamp: the only caller (`read_on_chain_configs`) already clamps to `get_first_txn_version`; on full-history nodes, pre-waypoint config reads now return the actual historical config instead of the waypoint-version config (this is the *correct* value — the previous behavior was flagged in the review).
- Rolling-upgrade safety: nodes with and without the fix interop — forged messages were never legitimate traffic.

## Type of Change

- [x] Bug fix (security)

## Which Components or Systems Does This Change Impact?

- [x] Validator Node
- [x] Full Node (state sync / event notifications)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I tested both happy and unhappy path of the functionality
