### PR TITLE
Fix deadlock in rayon pool

### DIFF
--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -46,24 +46,13 @@ use move_core_types::{
 };
 use move_vm_runtime::execution_tracing::Trace;
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
-use once_cell::sync::{Lazy, OnceCell};
+use once_cell::sync::OnceCell;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     marker::PhantomData,
-    sync::Arc,
 };
 use triomphe::Arc as TriompheArc;
 use vm_wrapper::AptosExecutorTask;
-
-static RAYON_EXEC_POOL: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .thread_name(|index| format!("par_exec-{}", index))
-            .build()
-            .unwrap(),
-    )
-});
 
 /// Output type wrapper used by block executor. VM output is stored first, then
 /// transformed into TransactionOutput type that is returned.
@@ -513,12 +502,11 @@ impl<
         >,
     > AptosBlockExecutorWrapper<E>
 {
-    pub fn execute_block_on_thread_pool<
+    pub fn execute_block<
         S: StateView + Sync,
         L: TransactionCommitHook,
         TP: TxnProvider<SignatureVerifiedTransaction, AuxiliaryInfo> + Sync,
     >(
-        executor_thread_pool: Arc<rayon::ThreadPool>,
         signature_verified_block: &TP,
         state_view: &S,
         module_cache_manager: &AptosModuleCacheManager,
@@ -546,7 +534,6 @@ impl<
         let executor =
             BlockExecutor::<SignatureVerifiedTransaction, E, S, L, TP, AuxiliaryInfo>::new(
                 config,
-                executor_thread_pool,
                 transaction_commit_listener,
             );
 
@@ -584,30 +571,6 @@ impl<
             }),
             Err(BlockExecutionError::FatalVMError(err)) => Err(err),
         }
-    }
-
-    /// Uses shared thread pool to execute blocks.
-    pub(crate) fn execute_block<
-        S: StateView + Sync,
-        L: TransactionCommitHook,
-        TP: TxnProvider<SignatureVerifiedTransaction, AuxiliaryInfo> + Sync,
-    >(
-        signature_verified_block: &TP,
-        state_view: &S,
-        module_cache_manager: &AptosModuleCacheManager,
-        config: BlockExecutorConfig,
-        transaction_slice_metadata: TransactionSliceMetadata,
-        transaction_commit_listener: Option<L>,
-    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
-        Self::execute_block_on_thread_pool::<S, L, TP>(
-            Arc::clone(&RAYON_EXEC_POOL),
-            signature_verified_block,
-            state_view,
-            module_cache_manager,
-            config,
-            transaction_slice_metadata,
-            transaction_commit_listener,
-        )
     }
 }
 

--- a/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
@@ -142,8 +142,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
             s.spawn(move |_| {
                 let txn_provider =
                     DefaultTxnProvider::new_without_info(signature_verified_transactions);
-                let ret = AptosVMBlockExecutorWrapper::execute_block_on_thread_pool(
-                    executor_thread_pool,
+                let ret = AptosVMBlockExecutorWrapper::execute_block(
                     &txn_provider,
                     aggr_overridden_state_view.as_ref(),
                     // Since we execute blocks in parallel, we cannot share module caches, so each

--- a/aptos-move/block-executor/src/combinatorial_tests/bencher.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/bencher.rs
@@ -32,7 +32,7 @@ use proptest::{
     strategy::{Strategy, ValueTree},
     test_runner::TestRunner,
 };
-use std::{fmt::Debug, hash::Hash, marker::PhantomData, sync::Arc};
+use std::{fmt::Debug, hash::Hash, marker::PhantomData};
 
 pub struct Bencher<K, V, E> {
     transaction_size: usize,
@@ -127,13 +127,6 @@ where
     pub(crate) fn run(self) {
         let state_view = MockStateView::empty();
 
-        let executor_thread_pool = Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(num_cpus::get())
-                .build()
-                .unwrap(),
-        );
-
         let config = BlockExecutorConfig::new_no_block_limit(num_cpus::get());
         let mut guard = AptosModuleCacheManagerGuard::none();
 
@@ -144,7 +137,7 @@ where
             NoOpTransactionCommitHook<usize>,
             DefaultTxnProvider<MockTransaction<KeyType<K>, E>, AuxiliaryInfo>,
             AuxiliaryInfo,
-        >::new(config, executor_thread_pool, None)
+        >::new(config, None)
         .execute_transactions_parallel(
             &self.txns_provider,
             &state_view,

--- a/aptos-move/block-executor/src/combinatorial_tests/delayed_field_tests.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/delayed_field_tests.rs
@@ -6,7 +6,7 @@ use crate::{
     combinatorial_tests::{
         group_tests::{create_non_empty_group_data_view, run_tests_with_groups},
         mock_executor::{MockEvent, MockTask},
-        resource_tests::{create_executor_thread_pool, get_gas_limit_variants},
+        resource_tests::get_gas_limit_variants,
         types::{KeyType, MockTransaction, TransactionGen, TransactionGenParams},
     },
     task::ExecutorTask,
@@ -66,12 +66,9 @@ fn delayed_field_transaction_tests(
 
     let data_view = create_non_empty_group_data_view(&key_universe, universe_size, true);
 
-    let executor_thread_pool = create_executor_thread_pool();
-
     let gas_limits = get_gas_limit_variants(use_gas_limit, transaction_count);
 
     run_tests_with_groups(
-        executor_thread_pool,
         gas_limits,
         transactions,
         &data_view,

--- a/aptos-move/block-executor/src/combinatorial_tests/delta_tests.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/delta_tests.rs
@@ -7,8 +7,7 @@ use crate::{
         baseline::BaselineOutput,
         mock_executor::{MockEvent, MockTask},
         resource_tests::{
-            create_executor_thread_pool, execute_block_parallel,
-            generate_universe_and_transactions, get_gas_limit_variants,
+            execute_block_parallel, generate_universe_and_transactions, get_gas_limit_variants,
         },
         types::{DeltaDataView, KeyType, MockTransaction},
     },
@@ -28,8 +27,6 @@ fn run_transactions_deltas(
     num_executions: usize,
     num_random_generations: usize,
 ) {
-    let executor_thread_pool = create_executor_thread_pool();
-
     // The delta threshold controls how many keys / paths are guaranteed r/w resources even
     // in the presence of deltas.
     let delta_threshold = std::cmp::min(15, universe_size / 2);
@@ -67,7 +64,6 @@ fn run_transactions_deltas(
                         AuxiliaryInfo,
                     >,
                 >(
-                    executor_thread_pool.clone(),
                     maybe_block_gas_limit,
                     &txn_provider,
                     &data_view,

--- a/aptos-move/block-executor/src/combinatorial_tests/group_tests.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/group_tests.rs
@@ -7,9 +7,7 @@ use crate::{
     combinatorial_tests::{
         baseline::BaselineOutput,
         mock_executor::{MockEvent, MockTask},
-        resource_tests::{
-            create_executor_thread_pool, execute_block_parallel, get_gas_limit_variants,
-        },
+        resource_tests::{execute_block_parallel, get_gas_limit_variants},
         types::{
             KeyType, MockTransaction, NonEmptyGroupDataView, TransactionGen, TransactionGenParams,
         },
@@ -27,7 +25,6 @@ use aptos_types::{
     transaction::AuxiliaryInfo,
 };
 use proptest::{collection::vec, prelude::*, strategy::ValueTree, test_runner::TestRunner};
-use std::sync::Arc;
 use test_case::test_case;
 
 /// Create a data view for testing with non-empty groups
@@ -47,7 +44,6 @@ pub(crate) fn create_non_empty_group_data_view(
 
 /// Run both parallel and sequential execution tests for a transaction provider
 pub(crate) fn run_tests_with_groups(
-    executor_thread_pool: Arc<rayon::ThreadPool>,
     gas_limits: Vec<Option<u64>>,
     transactions: Vec<MockTransaction<KeyType<[u8; 32]>, MockEvent>>,
     data_view: &NonEmptyGroupDataView<KeyType<[u8; 32]>>,
@@ -72,7 +68,6 @@ pub(crate) fn run_tests_with_groups(
                         AuxiliaryInfo,
                     >,
                 >(
-                    executor_thread_pool.clone(),
                     *maybe_block_gas_limit,
                     &txn_provider,
                     data_view,
@@ -99,7 +94,6 @@ pub(crate) fn run_tests_with_groups(
             AuxiliaryInfo,
         >::new(
             BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
-            executor_thread_pool.clone(),
             None,
         )
         .execute_transactions_sequential(
@@ -170,11 +164,9 @@ fn non_empty_group_transaction_tests(
         .collect();
 
     let data_view = create_non_empty_group_data_view(&key_universe, universe_size, false);
-    let executor_thread_pool = create_executor_thread_pool();
     let gas_limits = get_gas_limit_variants(use_gas_limit, transaction_count);
 
     run_tests_with_groups(
-        executor_thread_pool,
         gas_limits,
         transactions,
         &data_view,

--- a/aptos-move/block-executor/src/combinatorial_tests/module_tests.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/module_tests.rs
@@ -6,9 +6,7 @@ use crate::{
     combinatorial_tests::{
         baseline::BaselineOutput,
         mock_executor::{MockEvent, MockTask},
-        resource_tests::{
-            create_executor_thread_pool, execute_block_parallel, get_gas_limit_variants,
-        },
+        resource_tests::{execute_block_parallel, get_gas_limit_variants},
         types::{
             key_to_mock_module_id, KeyType, MockTransaction, TransactionGen, TransactionGenParams,
         },
@@ -49,7 +47,6 @@ fn execute_module_tests(
     assert!(fail::has_failpoints());
     fail::cfg("module_test", "return").unwrap();
 
-    let executor_thread_pool = create_executor_thread_pool();
     let mut runner = TestRunner::default();
 
     let module_id_pool = InternedModuleIdPool::new();
@@ -125,7 +122,6 @@ fn execute_module_tests(
                         AuxiliaryInfo,
                     >,
                 >(
-                    executor_thread_pool.clone(),
                     *maybe_block_gas_limit,
                     &txn_provider,
                     &state_view,

--- a/aptos-move/block-executor/src/combinatorial_tests/resource_tests.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/resource_tests.rs
@@ -50,15 +50,6 @@ pub(crate) fn get_gas_limit_variants(
     }
 }
 
-pub(crate) fn create_executor_thread_pool() -> Arc<rayon::ThreadPool> {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    )
-}
-
 /// Populates a module cache manager guard with empty modules for testing.
 /// This function creates empty modules for each ModuleId in the provided list and adds them to the guard's module cache.
 ///
@@ -99,7 +90,6 @@ pub(crate) fn populate_guard_with_modules(
 }
 
 pub(crate) fn execute_block_parallel<TxnType, ViewType, Provider>(
-    executor_thread_pool: Arc<rayon::ThreadPool>,
     block_gas_limit: Option<u64>,
     txn_provider: &Provider,
     data_view: &ViewType,
@@ -127,7 +117,7 @@ where
         NoOpTransactionCommitHook<usize>,
         Provider,
         AuxiliaryInfo,
-    >::new(config, executor_thread_pool, None);
+    >::new(config, None);
 
     if block_stm_v2 {
         block_executor.execute_transactions_parallel_v2(
@@ -184,7 +174,6 @@ pub(crate) fn run_transactions_resources(
     num_executions: usize,
     num_random_generations: usize,
 ) {
-    let executor_thread_pool = create_executor_thread_pool();
     let mut runner = TestRunner::default();
 
     let gas_limits = get_gas_limit_variants(use_gas_limit, transaction_count);
@@ -247,7 +236,6 @@ pub(crate) fn run_transactions_resources(
                             AuxiliaryInfo,
                         >,
                     >(
-                        executor_thread_pool.clone(),
                         *maybe_block_gas_limit,
                         &txn_provider,
                         &state_view,

--- a/aptos-move/block-executor/src/combinatorial_tests/tests.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/tests.rs
@@ -65,13 +65,6 @@ fn run_transactions<K, V, E>(
 
     let state_view = MockStateView::empty();
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
-
     let txn_provider = DefaultTxnProvider::new_without_info(transactions);
     for _ in 0..num_repeat {
         let mut guard = AptosModuleCacheManagerGuard::none();
@@ -84,7 +77,6 @@ fn run_transactions<K, V, E>(
             DefaultTxnProvider<MockTransaction<KeyType<K>, E>>,
         >::new(
             BlockExecutorConfig::new_maybe_block_limit(num_cpus::get(), maybe_block_gas_limit),
-            executor_thread_pool.clone(),
             None,
         )
         .execute_transactions_parallel(
@@ -209,13 +201,6 @@ fn deltas_writes_mixed_with_block_gas_limit(num_txns: usize, maybe_block_gas_lim
         phantom: PhantomData,
     };
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
-
     for _ in 0..20 {
         let mut guard = AptosModuleCacheManagerGuard::none();
 
@@ -227,7 +212,6 @@ fn deltas_writes_mixed_with_block_gas_limit(num_txns: usize, maybe_block_gas_lim
             DefaultTxnProvider<MockTransaction<KeyType<[u8; 32]>, MockEvent>>,
         >::new(
             BlockExecutorConfig::new_maybe_block_limit(num_cpus::get(), maybe_block_gas_limit),
-            executor_thread_pool.clone(),
             None,
         )
         .execute_transactions_parallel(
@@ -268,13 +252,6 @@ fn deltas_resolver_with_block_gas_limit(num_txns: usize, maybe_block_gas_limit: 
         .collect();
     let txn_provider = DefaultTxnProvider::new_without_info(transactions);
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
-
     for _ in 0..20 {
         let mut guard = AptosModuleCacheManagerGuard::none();
 
@@ -286,7 +263,6 @@ fn deltas_resolver_with_block_gas_limit(num_txns: usize, maybe_block_gas_limit: 
             DefaultTxnProvider<MockTransaction<KeyType<[u8; 32]>, MockEvent>>,
         >::new(
             BlockExecutorConfig::new_maybe_block_limit(num_cpus::get(), maybe_block_gas_limit),
-            executor_thread_pool.clone(),
             None,
         )
         .execute_transactions_parallel(
@@ -384,13 +360,6 @@ fn publishing_fixed_params_with_block_gas_limit(
         phantom: PhantomData,
     };
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
-
     let txn_provider = DefaultTxnProvider::new_without_info(transactions.clone());
     // Confirm still no intersection
     let mut guard = AptosModuleCacheManagerGuard::none();
@@ -402,7 +371,6 @@ fn publishing_fixed_params_with_block_gas_limit(
         DefaultTxnProvider<MockTransaction<KeyType<[u8; 32]>, MockEvent>>,
     >::new(
         BlockExecutorConfig::new_maybe_block_limit(num_cpus::get(), maybe_block_gas_limit),
-        executor_thread_pool,
         None,
     )
     .execute_transactions_parallel(
@@ -433,13 +401,6 @@ fn publishing_fixed_params_with_block_gas_limit(
         },
     };
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
-
     let txn_provider = DefaultTxnProvider::new_without_info(transactions);
     for _ in 0..200 {
         let mut guard = AptosModuleCacheManagerGuard::none();
@@ -455,7 +416,6 @@ fn publishing_fixed_params_with_block_gas_limit(
                 num_cpus::get(),
                 Some(max(w_index, r_index) as u64 * MAX_GAS_PER_TXN + 1),
             ),
-            executor_thread_pool.clone(),
             None,
         ) // Ensure enough gas limit to commit the module txns (4 is maximum gas per txn)
         .execute_transactions_parallel(
@@ -524,13 +484,6 @@ fn non_empty_group(
             .collect(),
     };
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
-
     for _ in 0..num_repeat_parallel {
         let mut guard = AptosModuleCacheManagerGuard::none();
 
@@ -542,7 +495,6 @@ fn non_empty_group(
             DefaultTxnProvider<MockTransaction<KeyType<[u8; 32]>, MockEvent>>,
         >::new(
             BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
-            executor_thread_pool.clone(),
             None,
         )
         .execute_transactions_parallel(
@@ -566,7 +518,6 @@ fn non_empty_group(
             DefaultTxnProvider<MockTransaction<KeyType<[u8; 32]>, MockEvent>>,
         >::new(
             BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
-            executor_thread_pool.clone(),
             None,
         )
         .execute_transactions_sequential(

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -68,15 +68,12 @@ use move_core_types::{language_storage::ModuleId, value::MoveTypeLayout, vm_stat
 use move_vm_runtime::{Module, RuntimeEnvironment, TypeChecker, WithRuntimeEnvironment};
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
 use num_cpus;
-use rayon::ThreadPool;
 use std::{
     cell::RefCell,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     marker::{PhantomData, Sync},
-    sync::{
-        atomic::{AtomicBool, AtomicU32, Ordering},
-        Arc,
-    },
+    sync::atomic::{AtomicBool, AtomicU32, Ordering},
+    thread,
 };
 use triomphe::Arc as TriompheArc;
 
@@ -99,11 +96,40 @@ where
     maybe_block_epilogue_txn_idx: &'a ExplicitSyncWrapper<Option<TxnIndex>>,
 }
 
+/// Spawns one Block-STM worker as a plain OS thread bound to `scope`.
+///
+/// Block-STM workers deliberately do **not** run on a rayon pool. A rayon worker
+/// that blocks is not idle: rayon's `wait_until` loop keeps it busy by stealing
+/// other jobs from its own pool onto that thread. So a worker that blocks inside a
+/// Move native's nested `par_iter()` can pick up a sibling worker task, and that
+/// stolen task can then block on state the original task still holds -- a
+/// writer-preferring `RwLock` over per-txn status, or a dependency condvar for the
+/// very transaction this thread had been executing. Neither side can make progress
+/// and the scheduler still believes the transaction is being executed.
+///
+/// Plain `std` threads are not registered with rayon, so a nested `par_iter()`
+/// runs on rayon's global pool while this thread parks on OS primitives, owing
+/// rayon nothing. That removes the cycle structurally, for every native, rather
+/// than requiring each rayon-using native to remember to isolate itself.
+fn spawn_block_stm_worker<'scope, F>(
+    scope: &'scope thread::Scope<'scope, '_>,
+    worker_id: u32,
+    worker: F,
+) where
+    F: FnOnce() + Send + 'scope,
+{
+    thread::Builder::new()
+        // Keep this short: Linux truncates thread names to 15 bytes, and the name is
+        // the fastest signal in a thread dump that these are not rayon workers.
+        .name(format!("blockstm-{}", worker_id))
+        .spawn_scoped(scope, worker)
+        .expect("failed to spawn Block-STM worker thread");
+}
+
 pub struct BlockExecutor<T, E, S, L, TP, A> {
-    // Number of active concurrent tasks, corresponding to the maximum number of rayon
-    // threads that may be concurrently participating in parallel execution.
+    // Number of active concurrent tasks, corresponding to the maximum number of
+    // worker threads that may be concurrently participating in parallel execution.
     config: BlockExecutorConfig,
-    executor_thread_pool: Arc<rayon::ThreadPool>,
     transaction_commit_hook: Option<L>,
     phantom: PhantomData<fn() -> (T, E, S, L, TP, A)>,
 }
@@ -119,11 +145,7 @@ where
 {
     /// The caller needs to ensure that concurrency_level > 1 (0 is illegal and 1 should
     /// be handled by sequential execution) and that concurrency_level <= num_cpus.
-    pub fn new(
-        config: BlockExecutorConfig,
-        executor_thread_pool: Arc<ThreadPool>,
-        transaction_commit_hook: Option<L>,
-    ) -> Self {
+    pub fn new(config: BlockExecutorConfig, transaction_commit_hook: Option<L>) -> Self {
         let num_cpus = num_cpus::get();
         assert!(
             config.local.concurrency_level > 0 && config.local.concurrency_level <= num_cpus,
@@ -133,7 +155,6 @@ where
         );
         Self {
             config,
-            executor_thread_pool,
             transaction_commit_hook,
             phantom: PhantomData,
         }
@@ -1763,9 +1784,9 @@ where
         let timer = RAYON_EXECUTION_SECONDS.start_timer();
         let worker_ids: Vec<u32> = (0..num_workers).collect();
         let maybe_executor = ExplicitSyncWrapper::new(None);
-        self.executor_thread_pool.scope(|s| {
+        thread::scope(|s| {
             for worker_id in &worker_ids {
-                s.spawn(|_| {
+                spawn_block_stm_worker(s, *worker_id, || {
                     let environment = module_cache_manager_guard.environment();
                     let executor = {
                         let _init_timer = VM_INIT_SECONDS.start_timer();
@@ -1920,9 +1941,9 @@ where
             worker_ids.len() as u32,
         );
 
-        self.executor_thread_pool.scope(|s| {
+        thread::scope(|s| {
             for worker_id in &worker_ids {
-                s.spawn(|_| {
+                spawn_block_stm_worker(s, *worker_id, || {
                     let environment = module_cache_manager_guard.environment();
                     let executor = {
                         let _init_timer = VM_INIT_SECONDS.start_timer();
@@ -2712,4 +2733,61 @@ fn should_perform_async_runtime_checks_for_block(
     _num_workers: u32,
 ) -> bool {
     environment.async_runtime_checks_enabled() && num_txns > 3
+}
+
+#[cfg(test)]
+mod worker_thread_tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Pins the invariant the Block-STM worker threading exists to guarantee: workers
+    /// must not be rayon workers, even when block execution is driven from inside a
+    /// rayon pool (as the sharded executor does). If a worker were rayon-registered,
+    /// blocking inside a Move native's nested `par_iter()` would let rayon steal
+    /// sibling worker tasks onto it, which is the deadlock this design rules out.
+    #[test]
+    fn workers_are_not_rayon_registered() {
+        let driver = rayon::ThreadPoolBuilder::new()
+            .num_threads(2)
+            .build()
+            .unwrap();
+        let observed: Mutex<Vec<(Option<usize>, Option<String>)>> = Mutex::new(Vec::new());
+
+        // Drive from a rayon worker: the worst case, and the one that used to deadlock.
+        driver.install(|| {
+            // Guards against the assertion below going vacuous: the driving thread really
+            // is rayon-registered, so `None` in a worker is a meaningful difference.
+            assert!(
+                rayon::current_thread_index().is_some(),
+                "test setup: driver should be a rayon worker"
+            );
+            thread::scope(|s| {
+                for worker_id in 0..4u32 {
+                    spawn_block_stm_worker(s, worker_id, || {
+                        observed.lock().unwrap().push((
+                            rayon::current_thread_index(),
+                            thread::current().name().map(str::to_string),
+                        ));
+                    });
+                }
+            });
+        });
+
+        let observed = observed.into_inner().unwrap();
+        assert_eq!(observed.len(), 4, "every worker should have run");
+        for (rayon_index, name) in &observed {
+            assert_eq!(
+                *rayon_index, None,
+                "Block-STM worker is registered with rayon as index {:?}; nested par_iter \
+                 in a native could steal sibling worker tasks onto it",
+                rayon_index
+            );
+            let name = name.as_deref().unwrap_or("");
+            assert!(
+                name.starts_with("blockstm-"),
+                "worker thread should be identifiable in a thread dump, got {:?}",
+                name
+            );
+        }
+    }
 }

--- a/aptos-move/block-executor/src/unit_tests/mod.rs
+++ b/aptos-move/block-executor/src/unit_tests/mod.rs
@@ -47,7 +47,6 @@ use std::{
     fmt::Debug,
     hash::Hash,
     marker::PhantomData,
-    sync::Arc,
 };
 
 #[test]
@@ -57,12 +56,6 @@ fn test_block_epilogue_happy_path() {
     let t_1 = MockTransaction::from_behavior(behaivor);
     let transactions = vec![t_0, t_1];
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -72,7 +65,6 @@ fn test_block_epilogue_happy_path() {
         AuxiliaryInfo,
     >::new(
         BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
-        executor_thread_pool,
         None,
     );
     let data_view = MockStateView::empty();
@@ -128,12 +120,6 @@ fn test_block_epilogue_block_gas_limit_reached() {
     let t_1 = MockTransaction::from_behavior(behaivor);
     let transactions = vec![t_0, t_1];
 
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -143,7 +129,6 @@ fn test_block_epilogue_block_gas_limit_reached() {
         AuxiliaryInfo,
     >::new(
         BlockExecutorConfig::new_maybe_block_limit(num_cpus::get(), Some(1)),
-        executor_thread_pool,
         None,
     );
     let data_view = MockStateView::empty();
@@ -223,12 +208,6 @@ fn test_resource_group_deletion() {
         group_keys: HashSet::new(),
         delayed_field_testing: false,
     };
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -238,7 +217,6 @@ fn test_resource_group_deletion() {
         AuxiliaryInfo,
     >::new(
         BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
-        executor_thread_pool,
         None,
     );
 
@@ -302,12 +280,6 @@ fn resource_group_bcs_fallback() {
         group_keys: HashSet::new(),
         delayed_field_testing: false,
     };
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -317,7 +289,6 @@ fn resource_group_bcs_fallback() {
         AuxiliaryInfo,
     >::new(
         BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
-        executor_thread_pool,
         None,
     );
 
@@ -418,12 +389,6 @@ fn interrupt_requested() {
     let mut guard = AptosModuleCacheManagerGuard::none();
 
     let data_view = MockStateView::empty();
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -433,7 +398,6 @@ fn interrupt_requested() {
         AuxiliaryInfo,
     >::new(
         BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
-        executor_thread_pool,
         None,
     );
 
@@ -465,12 +429,6 @@ fn block_output_err_precedence() {
     let txn_provider = DefaultTxnProvider::new_without_info(transactions);
 
     let data_view = MockStateView::empty();
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -480,7 +438,6 @@ fn block_output_err_precedence() {
         AuxiliaryInfo,
     >::new(
         BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
-        executor_thread_pool,
         None,
     );
 
@@ -509,12 +466,6 @@ fn skip_rest_gas_limit() {
     let txn_provider = DefaultTxnProvider::new_without_info(transactions);
 
     let data_view = MockStateView::empty();
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
     let block_executor = BlockExecutor::<
         MockTransaction<KeyType<u32>, MockEvent>,
         MockTask<KeyType<u32>, MockEvent>,
@@ -524,7 +475,6 @@ fn skip_rest_gas_limit() {
         AuxiliaryInfo,
     >::new(
         BlockExecutorConfig::new_maybe_block_limit(num_cpus::get(), Some(5)),
-        executor_thread_pool,
         None,
     );
 
@@ -544,13 +494,6 @@ where
     K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug + 'static,
     E: Send + Sync + Debug + Clone + TransactionEvent + 'static,
 {
-    let executor_thread_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build()
-            .unwrap(),
-    );
-
     let mut guard = AptosModuleCacheManagerGuard::none();
     let txn_provider = DefaultTxnProvider::new_without_info(transactions);
 
@@ -568,7 +511,6 @@ where
             AuxiliaryInfo,
         >::new(
             BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
-            executor_thread_pool,
             None,
         )
         .execute_transactions_parallel(
@@ -588,7 +530,6 @@ where
             AuxiliaryInfo,
         >::new(
             BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
-            executor_thread_pool,
             None,
         )
         .execute_transactions_parallel(

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -159,7 +159,7 @@ struct SharedCacheState {
 pub struct FakeExecutorImpl<O: OutputLogger> {
     state_store: FakeExecutorStateStore,
     event_store: Vec<ContractEvent>,
-    executor_thread_pool: Arc<rayon::ThreadPool>,
+    concurrency_level: usize,
     block_time: u64,
     executed_output: Option<O>,
     trace_dir: Option<PathBuf>,
@@ -229,12 +229,7 @@ pub enum ExecFuncTimerDynamicArgs {
 impl<O: OutputLogger> FakeExecutorImpl<O> {
     /// Creates an executor from a genesis [`WriteSet`].
     pub fn from_genesis(write_set: &WriteSet, chain_id: ChainId) -> Self {
-        let executor_thread_pool = Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(num_cpus::get())
-                .build()
-                .unwrap(),
-        );
+        let concurrency_level = num_cpus::get();
 
         let state_store = empty_in_memory_state_store();
         state_store.set_chain_id(chain_id).unwrap();
@@ -242,7 +237,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
         let mut executor = Self {
             state_store,
             event_store: Vec::new(),
-            executor_thread_pool,
+            concurrency_level,
             block_time: 0,
             executed_output: None,
             trace_dir: None,
@@ -256,10 +251,10 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
     }
 
     #[cfg(any(test, feature = "fuzzing"))]
-    pub fn from_genesis_with_existing_thread_pool(
+    pub fn from_genesis_with_concurrency_level(
         write_set: &WriteSet,
         chain_id: ChainId,
-        executor_thread_pool: Arc<rayon::ThreadPool>,
+        concurrency_level: usize,
         module_cache_manager: Option<AptosModuleCacheManager>,
     ) -> Self {
         let state_store = empty_in_memory_state_store();
@@ -268,7 +263,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
         let mut executor = Self {
             state_store,
             event_store: Vec::new(),
-            executor_thread_pool,
+            concurrency_level,
             block_time: 0,
             executed_output: None,
             trace_dir: None,
@@ -310,17 +305,12 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
             .get_on_chain_config::<CurrentTimeMicroseconds>()
             .expect("failed to get block time from remote");
 
-        let executor_thread_pool = Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(num_cpus::get())
-                .build()
-                .unwrap(),
-        );
+        let concurrency_level = num_cpus::get();
 
         Self {
             state_store,
             event_store: Vec::new(),
-            executor_thread_pool,
+            concurrency_level,
             block_time: timestamp.microseconds,
             executed_output: None,
             trace_dir: None,
@@ -461,16 +451,11 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
 
     /// Creates an executor in which no genesis state has been applied yet.
     pub fn no_genesis() -> Self {
-        let executor_thread_pool = Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(num_cpus::get())
-                .build()
-                .unwrap(),
-        );
+        let concurrency_level = num_cpus::get();
         Self {
             state_store: empty_in_memory_state_store(),
             event_store: Vec::new(),
-            executor_thread_pool,
+            concurrency_level,
             block_time: 0,
             executed_output: None,
             trace_dir: None,
@@ -844,12 +829,7 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
         let txn_provider = DefaultTxnProvider::new(txn_block, auxiliary_info);
         let metadata = self.get_txn_slice_metadata();
         let result = {
-            AptosVMBlockExecutorWrapper::execute_block_on_thread_pool::<
-                _,
-                NoOpTransactionCommitHook<VMStatus>,
-                _,
-            >(
-                self.executor_thread_pool.clone(),
+            AptosVMBlockExecutorWrapper::execute_block::<_, NoOpTransactionCommitHook<VMStatus>, _>(
                 &txn_provider,
                 &state_view,
                 self.module_cache_manager_opt()
@@ -1019,8 +999,8 @@ impl<O: OutputLogger> FakeExecutorImpl<O> {
         }
 
         let parallel_output = if mode != ExecutorMode::SequentialOnly {
-            // use the number of threads specified in the executor thread pool as specified at construction time
-            config.local.concurrency_level = self.executor_thread_pool.current_num_threads();
+            // use the concurrency level specified at construction time
+            config.local.concurrency_level = self.concurrency_level;
             Some(self.execute_transaction_block_impl_with_state_view(
                 sig_verified_block,
                 state_view,

--- a/execution/executor-benchmark/src/native/native_vm.rs
+++ b/execution/executor-benchmark/src/native/native_vm.rs
@@ -5,7 +5,7 @@
 use crate::{
     db_access::DbAccessUtil,
     native::{
-        native_config::{NativeConfig, NATIVE_EXECUTOR_POOL},
+        native_config::NativeConfig,
         native_transaction::{compute_deltas_for_batch, NativeTransaction},
     },
 };
@@ -69,7 +69,7 @@ use move_core_types::{
 };
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
 use serde::{de::DeserializeOwned, Serialize};
-use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
+use std::{collections::BTreeMap, fmt::Debug};
 
 pub struct NativeVMBlockExecutor;
 
@@ -91,12 +91,11 @@ impl VMBlockExecutor for NativeVMBlockExecutor {
         onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
     ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
-        AptosBlockExecutorWrapper::<NativeVMExecutorTask>::execute_block_on_thread_pool::<
+        AptosBlockExecutorWrapper::<NativeVMExecutorTask>::execute_block::<
             _,
             NoOpTransactionCommitHook<VMStatus>,
             _,
         >(
-            Arc::clone(&NATIVE_EXECUTOR_POOL),
             txn_provider,
             state_view,
             &AptosModuleCacheManager::new(),

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_authenticators.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_authenticators.rs
@@ -52,23 +52,14 @@ use utils::{
 static VM: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clone());
 
 const FUZZER_CONCURRENCY_LEVEL: usize = 1;
-static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(FUZZER_CONCURRENCY_LEVEL)
-            .build()
-            .unwrap(),
-    )
-});
-
 fn run_case(input: TransactionState) -> Result<(), Corpus> {
     tdbg!(&input);
 
     AptosVM::set_concurrency_level_once(FUZZER_CONCURRENCY_LEVEL);
-    let mut vm = FakeExecutor::from_genesis_with_existing_thread_pool(
+    let mut vm = FakeExecutor::from_genesis_with_concurrency_level(
         &VM,
         ChainId::mainnet(),
-        Arc::clone(&TP),
+        FUZZER_CONCURRENCY_LEVEL,
         None,
     )
     .set_not_parallel();

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish.rs
@@ -16,7 +16,7 @@ use move_binary_format::{
     file_format::{CompiledModule, CompiledScript},
 };
 use once_cell::sync::Lazy;
-use std::{collections::HashSet, sync::Arc};
+use std::collections::HashSet;
 use utils::vm::{group_modules_by_address_topo, publish_group};
 
 // genesis write set generated once for each fuzzing session
@@ -24,15 +24,6 @@ static VM: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clo
 
 const TEST_UPGRADE: bool = true;
 const FUZZER_CONCURRENCY_LEVEL: usize = 1;
-static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(FUZZER_CONCURRENCY_LEVEL)
-            .build()
-            .unwrap(),
-    )
-});
-
 fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
     tdbg!(&input);
 
@@ -72,10 +63,10 @@ fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
     let packages = group_modules_by_address_topo(input.dep_modules.clone())?;
 
     AptosVM::set_concurrency_level_once(FUZZER_CONCURRENCY_LEVEL);
-    let mut vm = FakeExecutor::from_genesis_with_existing_thread_pool(
+    let mut vm = FakeExecutor::from_genesis_with_concurrency_level(
         &VM,
         ChainId::mainnet(),
-        Arc::clone(&TP),
+        FUZZER_CONCURRENCY_LEVEL,
         None,
     )
     .set_not_parallel();

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
@@ -22,7 +22,7 @@ use move_binary_format::{
 };
 use move_core_types::vm_status::{StatusCode, StatusType};
 use once_cell::sync::Lazy;
-use std::{collections::HashSet, sync::Arc, time::Instant};
+use std::{collections::HashSet, time::Instant};
 mod utils;
 use fuzzer::{Authenticator, ExecVariant, RunnableState};
 use move_vm_runtime::RuntimeEnvironment;
@@ -35,15 +35,6 @@ use utils::vm::{
 static VM_WRITE_SET: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clone());
 
 const FUZZER_CONCURRENCY_LEVEL: usize = 1;
-static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(FUZZER_CONCURRENCY_LEVEL)
-            .build()
-            .unwrap(),
-    )
-});
-
 const MAX_TYPE_PARAMETER_VALUE: u16 = 64 / 4 * 16; // third_party/move/move-bytecode-verifier/src/signature_v2.rs#L1306-L1312
 
 const EXECUTION_TIME_GAS_RATIO: u8 = 100;
@@ -109,10 +100,10 @@ fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
     AptosVM::set_concurrency_level_once(FUZZER_CONCURRENCY_LEVEL);
     // Enable runtime reference-safety checks for the Move VM
     // prod_configs::set_paranoid_ref_checks(true);
-    let mut vm = FakeExecutor::from_genesis_with_existing_thread_pool(
+    let mut vm = FakeExecutor::from_genesis_with_concurrency_level(
         &VM_WRITE_SET,
         ChainId::mainnet(),
-        Arc::clone(&TP),
+        FUZZER_CONCURRENCY_LEVEL,
         None,
     )
     .set_not_parallel();

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run_transactional.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run_transactional.rs
@@ -29,10 +29,7 @@ use move_core_types::{
 };
 use move_transactional_test_runner::transactional_ops::TransactionalOperation;
 use once_cell::sync::Lazy;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::collections::{HashMap, HashSet};
 mod utils;
 use fuzzer::RunnableStateWithOperations;
 use utils::vm::{
@@ -44,15 +41,6 @@ use utils::vm::{
 static VM_WRITE_SET: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clone());
 
 const FUZZER_CONCURRENCY_LEVEL: usize = 4;
-static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(FUZZER_CONCURRENCY_LEVEL)
-            .build()
-            .unwrap(),
-    )
-});
-
 const MAX_TYPE_PARAMETER_VALUE: u16 = 64 / 4 * 16; // third_party/move/move-bytecode-verifier/src/signature_v2.rs#L1306-L1312
 
 // filter modules
@@ -136,10 +124,10 @@ fn run_case(input: RunnableStateWithOperations) -> Result<(), Corpus> {
 
     let module_cache_manager = AptosModuleCacheManager::new();
     AptosVM::set_concurrency_level_once(FUZZER_CONCURRENCY_LEVEL);
-    let mut vm = FakeExecutor::from_genesis_with_existing_thread_pool(
+    let mut vm = FakeExecutor::from_genesis_with_concurrency_level(
         &VM_WRITE_SET,
         ChainId::mainnet(),
-        Arc::clone(&TP),
+        FUZZER_CONCURRENCY_LEVEL,
         Some(module_cache_manager),
     )
     .set_parallel();


### PR DESCRIPTION
## Description

Block-STM workers ran on a rayon thread pool (`RAYON_EXEC_POOL`), which makes a
deadlock reachable from any user transaction that calls a rayon-using Move native.

A rayon worker that blocks is not idle. Rayon's `wait_until` loop keeps it busy by
stealing other jobs from its own pool onto that thread. So a worker that blocks
inside a Move native's nested `par_iter()` — `ark_ec` MSM, pairing, multi-pairing,
`ark_ff::batch_inversion` under `hash_to_structure` — can pick up a sibling worker
task, and that stolen task can then block on state the original task still holds:
the writer-preferring `RwLock` over per-txn status in `scheduler.rs`, or a v1
dependency condvar for the very transaction this thread had been executing. Neither
side progresses, and the scheduler still believes the transaction is executing.

Every precondition is present in this tree today:

- workers on rayon (`executor_thread_pool.scope(...)`, two sites in `executor.rs`)
- `parking_lot::RwLock` on `txn_status` and `DependencyCondvar` in `scheduler.rs`
- `ark-std 0.5.0` carries `rayon` in `Cargo.lock`, so the natives reach it
- `CRYPTOGRAPHY_ALGEBRA_NATIVES`, `BLS12_381_STRUCTURES` and `BN254_STRUCTURES` are
  all default-enabled, so the path is reachable from an ordinary transaction

This makes Block-STM workers plain OS threads via `std::thread::scope`. Threads not
registered with rayon cannot have rayon jobs stolen onto them; a native's nested
`par_iter()` runs on rayon's global pool while the worker parks on OS primitives.
That closes the whole class structurally — for every native, including ones nobody
remembered to isolate — rather than requiring each rayon-using native to opt in.

With the pool no longer driving workers, `RAYON_EXEC_POOL` had no remaining purpose
and is removed, along with the plumbing that existed only to carry it:

| Removed | Note |
| --- | --- |
| `RAYON_EXEC_POOL` | the `num_cpus`-thread `par_exec-*` pool |
| `BlockExecutor::new(config, pool, hook)` | now `new(config, hook)` |
| `execute_block_on_thread_pool(pool, …)` | merged into `execute_block(…)`; the wrapper only injected the pool |
| `create_executor_thread_pool()` + 12 per-test pools | test plumbing |
| pool params on `execute_block_parallel` / `run_tests_with_groups` | test plumbing |

Two call sites needed a real decision rather than a mechanical edit:

- **`FakeExecutor`** held a pool but only ever read `current_num_threads()` off it.
  Replaced with `concurrency_level: usize`, which is what the surrounding comment
  already said it wanted. `from_genesis_with_existing_thread_pool` becomes
  `from_genesis_with_concurrency_level`; the four fuzz targets that used it each
  built their pool with `num_threads(FUZZER_CONCURRENCY_LEVEL)`, so they now pass
  that constant directly — no behavior change.
- **`NATIVE_EXECUTOR_POOL`** (executor-benchmark) is kept. Unlike `RAYON_EXEC_POOL`
  it has independent `.install()` users in `aptos_vm_uncoordinated.rs` and
  `parallel_uncoordinated_block_executor.rs`. Only the argument was dropped.
  The sharded executor's pools are likewise kept — they drive the cross-shard commit
  receiver and aggregator, not Block-STM workers.

### Relationship to upstream

Motivated by aptos-labs/aptos-core@ad7011f771, which fixes the same deadlock class.
This implementation is independent, written from the failure mode rather than ported,
and diverges deliberately:

- upstream removes rayon from Block-STM via a hand-rolled persistent worker pool
  (~423 lines, using `mem::transmute` to forge a `'static` lifetime on the work
  closure, plus `catch_unwind`, a `Barrier`, and a panic slot). This uses
  `std::thread::scope`, which gives lifetime safety and panic propagation from the
  compiler instead.
- upstream's pool exists to amortise thread spawn across blocks. That matters most on
  their tree because their `with_native_rayon` keeps its per-caller rayon pool in a
  `thread_local!`, which scoped workers would rebuild every block. We do not carry
  `with_native_rayon`, so natives use rayon's process-wide global pool and nothing is
  rebuilt. Measured cost of the simpler approach here: ~185us per parallel block for
  16 workers, scaling down with block size (`num_workers` is
  `concurrency_level.min(num_txns / 2).max(2)`, so a small block spawns 2 threads).

If we later adopt `with_native_rayon` for defence in depth, that trade-off flips and
a persistent pool becomes worth revisiting.

## How Has This Been Tested?

- `cargo check --workspace --all-targets` — clean. This is the load-bearing check:
  per-crate checks miss `fuzzer-fuzz`, which is a separate package from `fuzzer`.
- `aptos-block-executor` lib suite, **237/237**: 98 combinatorial proptests (the
  randomised parallel-execution stress: contention, aborts, gas limits, delayed
  fields, resource groups), 113 scheduler/module tests, 26 unit + invariant tests.
- New regression test `executor::worker_thread_tests::workers_are_not_rayon_registered`
  pins the actual invariant: every worker sees `rayon::current_thread_index() == None`,
  driven from inside a rayon pool — the worst case, and the configuration the sharded
  executor uses. It also asserts the *driving* thread is rayon-registered, so it
  cannot pass vacuously.
- rustfmt clean on all 17 changed files; no new clippy findings.

Note for reviewers: `unit_tests::test_resource_group_deletion` is flaky and it is
**not** caused by this change. `resource_group_bcs_fallback` arms the process-global
failpoint `fail-point-resource-group-serialization` while libtest runs other tests in
parallel. Measured 6 failures in 8 runs both on this branch and with all files reverted
to the base commit — identical exposure — and 26/26 passes with `--test-threads=1`.
Worth a `serial_test` guard in a separate PR (`serial_test` is already a workspace dep).

## Key Areas to Review

- **`spawn_block_stm_worker` in `executor.rs`** — the core of the change. The doc
  comment carries the deadlock rationale; that reasoning is the thing to check.
- **Spawn-failure behaviour.** `.expect()` on `spawn_scoped` means that if worker *k*
  of *N* fails to spawn, `thread::scope` joins workers `0..k-1` first — they execute
  the whole block with fewer workers, then the panic propagates. Not a hang and not
  incorrect output (Block-STM has no barrier and no worker-count termination
  condition; `num_workers` is used only for `worker_id` bounds-checking and a
  scheduling heuristic), but it is a new failure mode in kind: with the pre-spawned
  pool, thread exhaustion could not fail block execution. Upstream avoids this by
  spawning all threads before dispatching any task.
- **Thread naming.** Workers are now `blockstm-{id}`; the rayon pool used
  `par_exec-{i}` and upstream kept that name. Nothing in-repo references `par_exec`
  any more, but external runbooks or thread-dump tooling might — this bug was
  originally diagnosed from a production thread dump. Happy to switch back.
- **`AptosBlockExecutorWrapper::execute_block`** widened from `pub(crate)` to `pub`,
  since it absorbed the public `execute_block_on_thread_pool`.
- **Sharded executor** still calls `execute_block` from a rayon worker. Harmless now
  (the VM runs on std threads beneath it) and it is not wired into `aptos-node`, but
  it is the one place the old shape survives.

## Type of Change

- [x] Bug fix
- [x] Refactoring

`BlockExecutor::new` loses its `Arc<rayon::ThreadPool>` parameter,
`execute_block_on_thread_pool` is removed in favour of `execute_block`, and
`FakeExecutor::from_genesis_with_existing_thread_pool` becomes
`from_genesis_with_concurrency_level`. All in-tree callers are updated.

## Which Components or Systems Does This Change Impact?

- [x] Validator Node
- [x] Move/Aptos Virtual Machine
- [x] Developer Infrastructure

## Checklist

- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

## Follow-ups (not in this PR)

- `aptos_rayon_execution_seconds` still names and describes a rayon pool that no
  longer exists. Left as-is for dashboard continuity — upstream `main` carries the
  same misnomer — but the description is now false and should be corrected.
- `serial_test` guard for the failpoint-using tests described above.
- Optionally port `with_native_rayon` for defence in depth, so the isolation does not
  depend solely on workers staying off rayon.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/movement-network/codesmith/aptos-core/pr/422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790953753&installation_model_id=17568&pr_number=422&repository=movement-network%2Faptos-core&return_to=https%3A%2F%2Fgithub.com%2Fmovement-network%2Faptos-core%2Fpull%2F422&signature=e693d857d2bad68d750fc8fe1fcccd9c0bcb0275c3febce5a92898fc737a0b8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->