### PR TITLE
Split KV restore/replay batches at epoch endings

### DIFF
--- a/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
@@ -59,6 +59,44 @@ use tokio::io::BufReader;
 
 const BATCH_SIZE: usize = if cfg!(test) { 2 } else { 10000 };
 
+/// Transaction plus the outputs KV-only replay applies to the DB.
+type KvReplayItem = (Transaction, TransactionInfo, WriteSet, Vec<ContractEvent>);
+
+fn kv_replay_item_ends_epoch(item: &KvReplayItem) -> bool {
+    item.3.iter().any(ContractEvent::is_new_epoch_event)
+}
+
+/// Seal KV-replay work so an epoch-ending item is always last in its group.
+///
+/// KV-only restore writes `VersionData` (storage usage) for the last version of
+/// each committed group. The first block of a new epoch reads usage at the
+/// prior epoch's last version. If that version sits in the middle of a group,
+/// the row is never persisted and later re-execution fails.
+///
+/// A group closes when it reaches `max_len` or when its newest item ends an
+/// epoch. The full-execution replay path already isolates epochs inside the
+/// chunk executor; this applies the same boundary rule to KV-only replay.
+fn seal_kv_replay_batches<T>(
+    items: impl IntoIterator<Item = T>,
+    max_len: usize,
+    ends_epoch: impl Fn(&T) -> bool,
+) -> Vec<Vec<T>> {
+    debug_assert!(max_len > 0, "KV replay batch length must be positive");
+    let mut sealed = Vec::new();
+    let mut open: Vec<T> = Vec::new();
+    for item in items {
+        let close_after = ends_epoch(&item);
+        open.push(item);
+        if close_after || open.len() >= max_len {
+            sealed.push(std::mem::take(&mut open));
+        }
+    }
+    if !open.is_empty() {
+        sealed.push(open);
+    }
+    sealed
+}
+
 #[derive(Parser)]
 pub struct TransactionRestoreOpt {
     #[clap(long = "transaction-manifest")]
@@ -524,6 +562,14 @@ impl TransactionRestoreBatchController {
             .try_chunks(BATCH_SIZE)
             .err_into::<anyhow::Error>()
             .map_ok(|chunk| {
+                stream::iter(
+                    seal_kv_replay_batches(chunk, BATCH_SIZE, kv_replay_item_ends_epoch)
+                        .into_iter()
+                        .map(Result::<_>::Ok),
+                )
+            })
+            .try_flatten()
+            .map_ok(|chunk| {
                 let (txns, txn_infos, write_sets, events): (Vec<_>, Vec<_>, Vec<_>, Vec<_>) =
                     chunk.into_iter().multiunzip();
                 let handler = arc_restore_handler.clone();
@@ -712,5 +758,99 @@ impl TransactionRestoreBatchController {
             })
             .await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod kv_replay_batch_tests {
+    use super::seal_kv_replay_batches;
+    use proptest::prelude::*;
+
+    /// Every epoch-ending item must be the last item of its group; groups stay
+    /// within `max_len` and concatenate back to the input.
+    fn assert_epoch_seal_invariant(flags: &[bool], max_len: usize, batches: &[Vec<bool>]) {
+        assert!(max_len > 0);
+        assert_eq!(
+            batches.iter().flatten().copied().collect::<Vec<_>>(),
+            flags,
+            "sealed groups must preserve input order and membership"
+        );
+        for batch in batches {
+            assert!(!batch.is_empty(), "sealed groups must be non-empty");
+            assert!(
+                batch.len() <= max_len,
+                "sealed group length {} exceeds max_len {}",
+                batch.len(),
+                max_len
+            );
+            for flag in batch.iter().take(batch.len() - 1) {
+                assert!(
+                    !*flag,
+                    "epoch-ending item must close its group; found one before the tail"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn empty_input_yields_no_groups() {
+        let batches = seal_kv_replay_batches(Vec::<bool>::new(), 4, |flag| *flag);
+        assert!(batches.is_empty());
+    }
+
+    #[test]
+    fn size_limit_alone_closes_groups() {
+        let flags = vec![false, false, false, false, false];
+        let batches = seal_kv_replay_batches(flags.clone(), 2, |flag| *flag);
+        assert_eq!(
+            batches,
+            vec![vec![false, false], vec![false, false], vec![false]]
+        );
+        assert_epoch_seal_invariant(&flags, 2, &batches);
+    }
+
+    #[test]
+    fn epoch_flag_closes_group_before_size_limit() {
+        // Epoch ending sits at index 2; with max_len 4 the first group must
+        // stop there so VersionData is written for that version.
+        let flags = vec![false, false, true, false, false];
+        let batches = seal_kv_replay_batches(flags.clone(), 4, |flag| *flag);
+        assert_eq!(batches, vec![vec![false, false, true], vec![false, false]]);
+        assert_epoch_seal_invariant(&flags, 4, &batches);
+    }
+
+    #[test]
+    fn consecutive_epoch_flags_each_form_their_own_group() {
+        let flags = vec![true, true, false];
+        let batches = seal_kv_replay_batches(flags.clone(), 8, |flag| *flag);
+        assert_eq!(batches, vec![vec![true], vec![true], vec![false]]);
+        assert_epoch_seal_invariant(&flags, 8, &batches);
+    }
+
+    #[test]
+    fn epoch_flag_at_size_limit_is_a_single_close() {
+        let flags = vec![false, true, false];
+        let batches = seal_kv_replay_batches(flags.clone(), 2, |flag| *flag);
+        assert_eq!(batches, vec![vec![false, true], vec![false]]);
+        assert_epoch_seal_invariant(&flags, 2, &batches);
+    }
+
+    #[test]
+    fn leading_epoch_flag_is_its_own_group() {
+        let flags = vec![true, false, false];
+        let batches = seal_kv_replay_batches(flags.clone(), 10, |flag| *flag);
+        assert_eq!(batches, vec![vec![true], vec![false, false]]);
+        assert_epoch_seal_invariant(&flags, 10, &batches);
+    }
+
+    proptest! {
+        #[test]
+        fn sealing_respects_epoch_and_size_bounds(
+            flags in prop::collection::vec(any::<bool>(), 0..48),
+            max_len in 1usize..12,
+        ) {
+            let batches = seal_kv_replay_batches(flags.clone(), max_len, |flag| *flag);
+            assert_epoch_seal_invariant(&flags, max_len, &batches);
+        }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Clean-room rewrite on `m1` (not a cherry-pick, patch, or mechanical port from aptos-labs). Upstream intent was read only to identify the bug and the invariant (`aptos-labs/aptos-core` commit message for KV replay splitting at epoch endings). Names, control flow, comments, and tests are original.

**Bug:** KV-only restore/replay batched transactions by size only. Storage usage (`VersionData`) is written for the last version of each batch. The first block of a new epoch reads usage at the previous epoch's last version (`state_storage::on_new_block`). When an epoch ending landed in the middle of a batch, that version had no usage row and later re-execution failed with `VersionData at <version> is missing`.

**Invariant:**
- A KV-replay group never contains an epoch-ending item except as its last item.
- No group is longer than `BATCH_SIZE`.
- Concatenating groups equals the original stream order.
- Full-execution replay already isolates epochs inside the chunk executor and is unchanged.

**What changed (crate `aptos-backup-cli` only):**
- `seal_kv_replay_batches` closes a group at `NewEpochEvent` (same predicate as the chunk executor / replay-on-archive) or at the existing size cap.
- `replay_kv` flattens those sealed groups before `save_transactions_and_replay_kv`, so `base_version` still advances in order.

## How Has This Been Tested?

```
cargo test -p aptos-backup-cli --locked
```

**27 passed; 0 failed; 1 ignored** (`backup_types::tests::test_end_to_end` was already ignored).

New coverage in `kv_replay_batch_tests`:
- empty input
- size-cap only
- epoch ending before the size cap
- consecutive epoch endings
- epoch ending exactly on the size cap
- leading epoch ending
- proptest: concatenation, non-empty groups, `len <= max_len`, and no epoch flag except at the tail of a group

CI: `rust-lints`, `rust-targeted-unit-tests`, `general-lints`, `rust-cargo-deny`, and the license check are green on this revision.

## Key Areas to Review

- `seal_kv_replay_batches` / `kv_replay_item_ends_epoch` in `storage/backup/backup-cli/src/backup_types/transaction/restore.rs`
- `replay_kv` now `try_flatten`s size-capped chunks after sealing at epoch endings

## Aikido / security notes (new code only)

Aikido MCP/CLI is not available in this environment. Manual review of the new code against `RUST_SECURE_CODING.md`:

- No `unsafe`.
- No new parsers, network surfaces, or third-party crates.
- `max_len` is the existing `BATCH_SIZE` constant (2 in tests, 10000 otherwise); `open.len() >= max_len` is `usize` comparison with no wrapping math.
- `debug_assert!(max_len > 0)` is a programmer check; a zero cap would still emit one-item groups rather than panic in release.
- No `unwrap`/`expect` on restore input; epoch detection uses the existing `ContractEvent::is_new_epoch_event` predicate.
- Extra groups only increase DB commit granularity; they do not accept extra user data.

Please run the project Aikido workflow on the PR if that is part of CI.

## Type of Change
- [x] Bug fix
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Other (specify): storage backup restore / KV-only replay (`aptos-backup-cli`)

## Checklist
- [x] Clean-room implementation; no aptos-labs commit SHAs, patches, or copied function bodies
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I tested both happy and unhappy path of the functionality

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f7b32c3-ba27-4cfa-8c81-97a4812c39a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f7b32c3-ba27-4cfa-8c81-97a4812c39a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/movement-network/codesmith/aptos-core/pr/423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791262936&installation_model_id=17568&pr_number=423&repository=movement-network%2Faptos-core&return_to=https%3A%2F%2Fgithub.com%2Fmovement-network%2Faptos-core%2Fpull%2F423&signature=8577bfd5dcb26ae0bf1d89ed5d13065775097552d5213cf079b6314a8409ae55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->