### PR TITLE
Reject oversized JSON submit batches before verify

### DIFF
--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -1271,6 +1271,97 @@ async fn test_submit_transaction_rejects_invalid_json() {
     context.check_golden_output(resp);
 }
 
+/// Oversized JSON batches must fail on the count cap, even when every item
+/// would also fail `VerifyInput` (expired timestamp). That shows verify()
+/// never walks the array.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_submit_batch_rejects_oversized_json_before_verify() {
+    let mut node_config = NodeConfig::default();
+    node_config.api.max_submit_transaction_batch_size = 1;
+    let mut context = new_test_context_with_config(current_function_name!(), node_config);
+
+    let expired = parseable_expired_json_submit_request();
+    let resp = context
+        .expect_status_code(400)
+        .post("/transactions/batch", json!([expired.clone(), expired]))
+        .await;
+
+    assert_eq!(resp["error_code"], "invalid_input");
+    let message = resp["message"].as_str().expect("error message");
+    assert!(
+        message.contains("Submitted too many transactions: 2"),
+        "expected size-cap error, got {message}"
+    );
+    assert!(
+        message.contains("limit is 1"),
+        "expected configured limit in error, got {message}"
+    );
+    assert!(
+        !message.to_ascii_lowercase().contains("expiration"),
+        "size cap must run before verify(); got {message}"
+    );
+}
+
+/// A JSON batch at the configured limit is still verified item-by-item.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_submit_batch_json_at_limit_still_verifies_items() {
+    let mut node_config = NodeConfig::default();
+    node_config.api.max_submit_transaction_batch_size = 2;
+    let mut context = new_test_context_with_config(current_function_name!(), node_config);
+
+    let expired = parseable_expired_json_submit_request();
+    let resp = context
+        .expect_status_code(400)
+        .post("/transactions/batch", json!([expired.clone(), expired]))
+        .await;
+
+    assert_eq!(resp["error_code"], "invalid_input");
+    let message = resp["message"].as_str().expect("error message");
+    assert!(
+        !message.contains("Submitted too many transactions"),
+        "batch of size == limit must not trip the cap; got {message}"
+    );
+    assert!(
+        message.to_ascii_lowercase().contains("expiration")
+            || message.to_ascii_lowercase().contains("past"),
+        "expected verify() to reject expired items; got {message}"
+    );
+}
+
+/// BCS batches cannot be counted until they are decoded, so the same cap
+/// still applies after `get_signed_transactions_batch`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_submit_batch_rejects_oversized_bcs_after_decode() {
+    let mut node_config = NodeConfig::default();
+    node_config.api.max_submit_transaction_batch_size = 1;
+    let mut context = new_test_context_with_config(current_function_name!(), node_config);
+
+    let mut root_account = context.root_account().await;
+    let first = context.gen_account();
+    let second = context.gen_account();
+    let txns = vec![
+        context.create_user_account_by(&mut root_account, &first),
+        context.create_user_account_by(&mut root_account, &second),
+    ];
+    let body = bcs::to_bytes(&txns).unwrap();
+
+    let resp = context
+        .expect_status_code(400)
+        .post_bcs_txn("/transactions/batch", body)
+        .await;
+
+    assert_eq!(resp["error_code"], "invalid_input");
+    let message = resp["message"].as_str().expect("error message");
+    assert!(
+        message.contains("Submitted too many transactions: 2"),
+        "expected size-cap error, got {message}"
+    );
+    assert!(
+        message.contains("limit is 1"),
+        "expected configured limit in error, got {message}"
+    );
+}
+
 #[ignore]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_create_signing_message_rejects_payload_too_large_json_body() {
@@ -1729,6 +1820,29 @@ fn gen_string(len: u64) -> String {
         .map(|()| rng.sample(Alphanumeric))
         .take(len as usize)
         .collect()
+}
+
+/// JSON that deserializes as `SubmitTransactionRequest` but fails verify()
+/// because the expiration is already in the past.
+fn parseable_expired_json_submit_request() -> serde_json::Value {
+    json!({
+        "sender": "0x1",
+        "sequence_number": "0",
+        "max_gas_amount": "1",
+        "gas_unit_price": "0",
+        "expiration_timestamp_secs": "1",
+        "payload": {
+            "type": "entry_function_payload",
+            "function": "0x1::aptos_account::create_account",
+            "type_arguments": [],
+            "arguments": ["0x2"],
+        },
+        "signature": {
+            "type": "ed25519_signature",
+            "public_key": "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "signature": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002",
+        },
+    })
 }
 
 // For use when not using the methods on `TestContext` directly.

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -1278,7 +1278,7 @@ async fn test_submit_transaction_rejects_invalid_json() {
 async fn test_submit_batch_rejects_oversized_json_before_verify() {
     let mut node_config = NodeConfig::default();
     node_config.api.max_submit_transaction_batch_size = 1;
-    let mut context = new_test_context_with_config(current_function_name!(), node_config);
+    let context = new_test_context_with_config(current_function_name!(), node_config);
 
     let expired = parseable_expired_json_submit_request();
     let resp = context
@@ -1307,7 +1307,7 @@ async fn test_submit_batch_rejects_oversized_json_before_verify() {
 async fn test_submit_batch_json_at_limit_still_verifies_items() {
     let mut node_config = NodeConfig::default();
     node_config.api.max_submit_transaction_batch_size = 2;
-    let mut context = new_test_context_with_config(current_function_name!(), node_config);
+    let context = new_test_context_with_config(current_function_name!(), node_config);
 
     let expired = parseable_expired_json_submit_request();
     let resp = context

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -495,6 +495,9 @@ impl TransactionsApi {
         accept_type: AcceptType,
         data: SubmitTransactionsBatchPost,
     ) -> SubmitTransactionsBatchResult<TransactionsBatchSubmissionResult> {
+        // JSON already exposes its array length. Cap it before verify() so an
+        // oversized batch cannot force per-item payload / signature checks.
+        self.reject_json_batch_if_over_configured_limit(&data)?;
         data.verify()
             .context("Submitted transactions invalid")
             .map_err(|err| {
@@ -511,6 +514,8 @@ impl TransactionsApi {
             .check_api_output_enabled("Submit batch transactions", &accept_type)?;
         let ledger_info = self.context.get_latest_ledger_info()?;
         let signed_transactions_batch = self.get_signed_transactions_batch(&ledger_info, data)?;
+        // BCS (and any other encoding) only reveals the count after decode.
+        // JSON is already gated above; this remains the backstop after parse.
         if self.context.max_submit_transaction_batch_size() < signed_transactions_batch.len() {
             return Err(SubmitTransactionError::bad_request_with_code(
                 format!(
@@ -1312,6 +1317,30 @@ impl TransactionsApi {
                         ledger_info,
                     )
                 })?;
+        }
+        Ok(())
+    }
+
+    /// Refuse a JSON submit-batch whose array is already larger than
+    /// `max_submit_transaction_batch_size`. BCS is skipped here because the
+    /// transaction count is unknown until the bytes are decoded.
+    fn reject_json_batch_if_over_configured_limit(
+        &self,
+        data: &SubmitTransactionsBatchPost,
+    ) -> Result<(), SubmitTransactionError> {
+        let SubmitTransactionsBatchPost::Json(json_batch) = data else {
+            return Ok(());
+        };
+        let submitted = json_batch.0.len();
+        let limit = self.context.max_submit_transaction_batch_size();
+        if submitted > limit {
+            return Err(SubmitTransactionError::bad_request_with_code_no_info(
+                format!(
+                    "Submitted too many transactions: {}, while limit is {}",
+                    submitted, limit
+                ),
+                AptosErrorCode::InvalidInput,
+            ));
         }
         Ok(())
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Clean-room rewrite of the **intent** of aptos-labs/aptos-core@fe434ebe (early JSON batch size check). **No aptos-labs code was cherry-picked or copied.** This change was written from scratch against the m1 handler.

**Problem:** `POST /transactions/batch` accepted a JSON array, then ran `VerifyInput` (and later signed-txn conversion) on every item *before* enforcing `max_submit_transaction_batch_size`. An oversized JSON batch could burn CPU on payload/signature checks that would be discarded.

**Invariant:** If a JSON submit-batch array is already longer than `max_submit_transaction_batch_size`, the handler returns `400` / `invalid_input` **before** `verify()` and **before** `get_signed_transactions_batch`. BCS cannot be counted until it is decoded, so the existing post-parse cap stays as the BCS path (and as a backstop).

**What changed (crate `api` only):**
- `reject_json_batch_if_over_configured_limit` runs first on `SubmitTransactionsBatchPost::Json`.
- The post-decode size check is unchanged for BCS.

## How Has This Been Tested?

Ran locally:

```
cargo test -p aptos-api --lib test_submit_batch
```

`3 passed; 0 failed`

- `test_submit_batch_rejects_oversized_json_before_verify` — two expired-but-parseable JSON items with limit `1` fail on the count cap, not expiration (proves verify is skipped).
- `test_submit_batch_json_at_limit_still_verifies_items` — two expired items with limit `2` still fail verify (cap is `>`, not `>=`).
- `test_submit_batch_rejects_oversized_bcs_after_decode` — two signed txns as BCS with limit `1` still 400 after decode.

## Key Areas to Review

- Ordering in `submit_transactions_batch`: JSON length gate, then `verify()`, then decode, then BCS backstop.
- Error text matches the existing late-check message so clients that parse it keep working.

## Aikido / security notes (new code only)

- **DoS:** this is a request-count gate, not a body-size gate. It stops per-item verify work after JSON deserialize. HTTP `Content-Length` is still handled by existing `PostSizeLimit`.
- **Comparison:** `submitted > limit` on `usize`; no wrapping math, no `unwrap` on user input.
- **BCS:** count is unknown until decode; we still deserialize then refuse before mempool submit. That decode cost is unavoidable for BCS.
- **Errors:** same `InvalidInput` + message shape as the existing late check. Early JSON path uses `bad_request_with_code_no_info` because ledger headers are not fetched yet.
- **No unsafe / no new parsers.**

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [x] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I tested both happy and unhappy path of the functionality

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3a7213d-e172-45cd-ac66-074fdaa41547?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3a7213d-e172-45cd-ac66-074fdaa41547&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/movement-network/codesmith/aptos-core/pr/424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791262942&installation_model_id=17568&pr_number=424&repository=movement-network%2Faptos-core&return_to=https%3A%2F%2Fgithub.com%2Fmovement-network%2Faptos-core%2Fpull%2F424&signature=33be842dafc8b3da0680c2d38c5d0b60dfd2104b3e3a8b6346c48fad6357da17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->