### PR TITLE
Make MoveStructLayout field accessors fail-closed on unknown tags

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,3 +3,29 @@
 The Aptos Foundation welcomes feedback from security researchers and the general public to help improve the security of the Aptos Network, and, at its sole discretion, offers bounty rewards for security reports that identify previously unknown, in-scope security vulnerabilities.
 
 To learn more visit the [Aptos Foundation Bounty Program](https://hackenproof.com/aptos) page.
+
+## Move VM: fail-closed struct and enum field layouts
+
+`MoveStructLayout::fields` and `MoveStructLayout::into_fields` return `Option`.
+A missing, inconsistent, or out-of-range `RuntimeVariants` tag is `None`. It is
+never an empty field list.
+
+An empty field list is a valid unit variant (`Some(&[])` / `Some(vec![])`).
+Substituting `&[]` for an unknown tag lets a caller treat a bad tag as a unit
+variant. BCS serialization would then emit bytes that strict deserialization
+rejects — a serialize/deserialize asymmetry that can wedge state after an enum
+upgrade (a resource that can be written but never read back).
+
+Movement [#411](https://github.com/movement-network/aptos-core/pull/411) closed
+that hole on the BCS serialize path by rejecting out-of-range tags in
+`try_get_variant_field_layouts`. The layout accessors themselves still returned
+an empty slice, so other walkers (`as_move_value`, delayed-field string
+recognition) could still treat a bad tag as a unit variant.
+
+Invariant:
+
+- Serialization must not emit an unknown variant tag.
+- Every `fields` / `into_fields` caller must handle `None` and must not fall
+  back to empty fields.
+
+This change does not enable feature flags 81 or 95.

--- a/third_party/move/move-core/types/src/unit_tests/value_test.rs
+++ b/third_party/move/move-core/types/src/unit_tests/value_test.rs
@@ -7,7 +7,7 @@ use crate::{
     ident_str,
     identifier::Identifier,
     language_storage::{StructTag, TypeTag},
-    value::{MoveStruct, MoveValue},
+    value::{MoveFieldLayout, MoveStruct, MoveStructLayout, MoveTypeLayout, MoveValue, MoveVariantLayout},
 };
 use serde_json::json;
 
@@ -136,4 +136,101 @@ fn nested_typed_struct_deserialization() {
             "type": "0x0::MyModule::MyStruct"
         })
     );
+}
+
+/// RuntimeVariants layout used by the fail-closed field-accessor tests:
+/// variant 0 has one field, variant 1 is a unit variant.
+fn enum_layout() -> MoveStructLayout {
+    MoveStructLayout::RuntimeVariants(vec![
+        vec![MoveTypeLayout::U64],
+        vec![],
+    ])
+}
+
+#[test]
+fn fields_returns_some_for_consistent_runtime_queries() {
+    let runtime = MoveStructLayout::Runtime(vec![MoveTypeLayout::Bool, MoveTypeLayout::U8]);
+    assert_eq!(
+        runtime.fields(None),
+        Some([MoveTypeLayout::Bool, MoveTypeLayout::U8].as_slice())
+    );
+
+    let variants = enum_layout();
+    assert_eq!(
+        variants.fields(Some(0)),
+        Some([MoveTypeLayout::U64].as_slice())
+    );
+    // A genuine unit variant is Some(&[]), not None.
+    assert_eq!(variants.fields(Some(1)), Some([].as_slice()));
+}
+
+#[test]
+fn fields_returns_none_for_unknown_or_inconsistent_tags() {
+    let runtime = MoveStructLayout::Runtime(vec![MoveTypeLayout::U64]);
+    // Structs are not enums: asking for a variant is inconsistent.
+    assert_eq!(runtime.fields(Some(0)), None);
+
+    let variants = enum_layout();
+    assert_eq!(variants.fields(None), None);
+    for bad in [2usize, 3, 100, usize::MAX] {
+        assert_eq!(
+            variants.fields(Some(bad)),
+            None,
+            "out-of-range tag {bad} must not collapse to an empty unit variant"
+        );
+    }
+
+    let decorated = MoveStructLayout::WithFields(vec![MoveFieldLayout::new(
+        ident_str!("x").to_owned(),
+        MoveTypeLayout::U8,
+    )]);
+    assert_eq!(decorated.fields(None), None);
+}
+
+#[test]
+fn into_fields_is_fail_closed_like_fields() {
+    let runtime = MoveStructLayout::Runtime(vec![MoveTypeLayout::U32]);
+    assert_eq!(
+        runtime.clone().into_fields(None),
+        Some(vec![MoveTypeLayout::U32])
+    );
+    assert_eq!(runtime.into_fields(Some(0)), None);
+
+    let variants = enum_layout();
+    assert_eq!(
+        variants.clone().into_fields(Some(0)),
+        Some(vec![MoveTypeLayout::U64])
+    );
+    assert_eq!(variants.clone().into_fields(Some(1)), Some(vec![]));
+    assert_eq!(variants.clone().into_fields(None), None);
+    assert_eq!(variants.into_fields(Some(2)), None);
+
+    let with_fields = MoveStructLayout::WithFields(vec![MoveFieldLayout::new(
+        ident_str!("f").to_owned(),
+        MoveTypeLayout::Bool,
+    )]);
+    assert_eq!(
+        with_fields.into_fields(None),
+        Some(vec![MoveTypeLayout::Bool])
+    );
+
+    let with_variants = MoveStructLayout::WithVariants(vec![
+        MoveVariantLayout {
+            name: ident_str!("A").to_owned(),
+            fields: vec![MoveFieldLayout::new(
+                ident_str!("x").to_owned(),
+                MoveTypeLayout::U8,
+            )],
+        },
+        MoveVariantLayout {
+            name: ident_str!("B").to_owned(),
+            fields: vec![],
+        },
+    ]);
+    assert_eq!(
+        with_variants.clone().into_fields(Some(0)),
+        Some(vec![MoveTypeLayout::U8])
+    );
+    assert_eq!(with_variants.clone().into_fields(Some(1)), Some(vec![]));
+    assert_eq!(with_variants.into_fields(Some(2)), None);
 }

--- a/third_party/move/move-core/types/src/value.rs
+++ b/third_party/move/move-core/types/src/value.rs
@@ -535,52 +535,55 @@ impl MoveStructLayout {
         }
     }
 
-    pub fn fields(&self, variant: Option<usize>) -> &[MoveTypeLayout] {
-        match self {
-            Self::Runtime(vals) => vals,
-            Self::RuntimeVariants(variants) => match variant {
-                Some(idx) if idx < variants.len() => &variants[idx],
-                _ => {
-                    // API does not allow to return error, return empty fields instead of crashing
-                    &[]
-                },
+    /// Field layouts for this struct, or for one selected enum variant.
+    ///
+    /// Returns `None` when the query is inconsistent with the layout:
+    /// - `Runtime` requires `variant == None`
+    /// - `RuntimeVariants` requires `Some(idx)` in range
+    /// - decorated layouts are not available through this borrowed accessor
+    ///   (strip names with [`Self::into_fields`] instead)
+    ///
+    /// `None` must be treated as failure. An empty slice is a *valid* unit
+    /// variant (`Some(&[])`). Substituting `&[]` for an unknown tag would let
+    /// callers treat a bad tag as a unit variant and emit BCS that strict
+    /// deserialization rejects.
+    pub fn fields(&self, variant: Option<usize>) -> Option<&[MoveTypeLayout]> {
+        match (self, variant) {
+            (Self::Runtime(vals), None) => Some(vals),
+            (Self::RuntimeVariants(variants), Some(idx)) => {
+                variants.get(idx).map(Vec::as_slice)
             },
-            Self::WithFields(_) | Self::WithTypes { .. } | Self::WithVariants(_) => {
-                // It's not possible to implement this without changing the return type, and some
-                // performance-critical VM serialization code uses the Runtime case of this.
-                // panicking is the best move
-                panic!("Getting fields for decorated representation")
-            },
+            // Decorated structs store named fields; this borrowed accessor is
+            // only defined for the undecorated runtime struct case.
+            (Self::WithFields(_) | Self::WithTypes { .. } | Self::WithVariants(_), _)
+            | (Self::Runtime(_), Some(_))
+            | (Self::RuntimeVariants(_), None) => None,
         }
     }
 
-    pub fn into_fields(self, variant: Option<usize>) -> Vec<MoveTypeLayout> {
-        match self {
-            Self::Runtime(vals) => vals,
-            Self::RuntimeVariants(mut variants) => {
-                match variant {
-                    Some(idx) if idx < variants.len() => variants.remove(idx),
-                    _ => {
-                        // be on the robust side and remove empty vec instead of crash
-                        vec![]
-                    },
-                }
+    /// Owned field layouts for this struct, or for one selected enum variant.
+    ///
+    /// Same fail-closed contract as [`Self::fields`]: `None` for an inconsistent
+    /// query or an out-of-range variant. Decorated layouts are supported here
+    /// because the named-field wrappers can be stripped while moving.
+    pub fn into_fields(self, variant: Option<usize>) -> Option<Vec<MoveTypeLayout>> {
+        match (self, variant) {
+            (Self::Runtime(vals), None) => Some(vals),
+            (Self::RuntimeVariants(mut variants), Some(idx)) if idx < variants.len() => {
+                Some(variants.remove(idx))
             },
-            Self::WithFields(fields) | Self::WithTypes { fields, .. } => {
-                fields.into_iter().map(|f| f.layout).collect()
+            (Self::WithFields(fields), None) | (Self::WithTypes { fields, .. }, None) => {
+                Some(fields.into_iter().map(|f| f.layout).collect())
             },
-            Self::WithVariants(mut variants) => match variant {
-                Some(idx) if idx < variants.len() => variants
+            (Self::WithVariants(mut variants), Some(idx)) if idx < variants.len() => Some(
+                variants
                     .remove(idx)
                     .fields
                     .into_iter()
                     .map(|f| f.layout)
                     .collect(),
-                _ => {
-                    // be on the robust side and return empty vec instead of crash
-                    vec![]
-                },
-            },
+            ),
+            _ => None,
         }
     }
 

--- a/third_party/move/move-vm/types/src/delayed_values/derived_string_snapshot.rs
+++ b/third_party/move/move-vm/types/src/delayed_values/derived_string_snapshot.rs
@@ -15,7 +15,7 @@ use std::str::FromStr;
 fn is_string_layout(layout: &MoveTypeLayout) -> bool {
     use MoveTypeLayout as L;
     if let L::Struct(move_struct) = layout {
-        if let [L::Vector(elem)] = move_struct.fields(None).iter().as_slice() {
+        if let Some([L::Vector(elem)]) = move_struct.fields(None) {
             if let L::U8 = elem.as_ref() {
                 return true;
             }
@@ -27,7 +27,7 @@ fn is_string_layout(layout: &MoveTypeLayout) -> bool {
 pub fn is_derived_string_struct_layout(layout: &MoveTypeLayout) -> bool {
     use MoveTypeLayout as L;
     if let L::Struct(move_struct) = layout {
-        if let [value_field, L::Vector(padding_elem)] = move_struct.fields(None).iter().as_slice() {
+        if let Some([value_field, L::Vector(padding_elem)]) = move_struct.fields(None) {
             if is_string_layout(value_field) {
                 if let L::U8 = padding_elem.as_ref() {
                     return true;
@@ -141,6 +141,44 @@ mod tests {
     #[test]
     fn test_int_to_string_fails_on_small_width() {
         assert_err!(u64_to_fixed_size_utf8_bytes(1000, 1));
+    }
+
+    #[test]
+    fn enum_layouts_are_not_string_or_derived_string() {
+        use move_core_types::value::MoveStructLayout;
+
+        // fields(None) on RuntimeVariants is None. That must not be treated as
+        // a String (vector<u8> wrapper) or DerivedStringSnapshot — including
+        // when a variant happens to look like those structs.
+        let enum_layout = MoveTypeLayout::Struct(MoveStructLayout::RuntimeVariants(vec![
+            vec![],
+            vec![MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8))],
+            vec![
+                MoveTypeLayout::Struct(MoveStructLayout::Runtime(vec![MoveTypeLayout::Vector(
+                    Box::new(MoveTypeLayout::U8),
+                )])),
+                MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),
+            ],
+        ]));
+        assert!(!is_string_layout(&enum_layout));
+        assert!(!is_derived_string_struct_layout(&enum_layout));
+    }
+
+    #[test]
+    fn runtime_string_layouts_still_match() {
+        use move_core_types::value::MoveStructLayout;
+
+        let string = MoveTypeLayout::Struct(MoveStructLayout::Runtime(vec![
+            MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),
+        ]));
+        assert!(is_string_layout(&string));
+
+        let derived = MoveTypeLayout::Struct(MoveStructLayout::Runtime(vec![
+            string.clone(),
+            MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),
+        ]));
+        assert!(is_derived_string_struct_layout(&derived));
+        assert!(!is_string_layout(&derived));
     }
 
     #[test]

--- a/third_party/move/move-vm/types/src/values/serialization_tests.rs
+++ b/third_party/move/move-vm/types/src/values/serialization_tests.rs
@@ -178,6 +178,17 @@ mod tests {
         }
     }
 
+    #[test]
+    #[should_panic(expected = "variant tag 3 is out of range")]
+    fn as_move_value_rejects_out_of_range_unit_tag() {
+        // as_move_value used to zip an unknown tag against an empty field
+        // list, producing a unit-variant MoveValue. That is the same hole
+        // serialize already rejects.
+        let layout = enum_layout();
+        let bad = Value::struct_(Struct::pack_variant(3, iter::empty()));
+        let _ = bad.as_move_value(&layout);
+    }
+
     // ---------------------------------------------------------------------------
     // Rust cross-serialization tests
 

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -4068,7 +4068,15 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveStructLayout, 
                 },
             }
         } else {
-            let field_layouts = self.layout.fields(None);
+            let field_layouts = match self.layout.fields(None) {
+                Some(field_layouts) => field_layouts,
+                None => {
+                    return Err(invariant_violation::<S>(format!(
+                        "cannot serialize struct value {:?} as {:?} -- field layouts unavailable",
+                        self.value, self.layout
+                    )));
+                },
+            };
             let mut t = serializer.serialize_tuple(values.len())?;
             if field_layouts.len() != values.len() {
                 return Err(invariant_violation::<S>(format!(
@@ -4807,17 +4815,24 @@ pub mod prop {
                     })
                     .boxed(),
             },
-            L::Struct(struct_layout @ MoveStructLayout::RuntimeVariants(variants)) => struct_layout
+            L::Struct(struct_layout @ MoveStructLayout::RuntimeVariants(variants)) => {
                 // TODO(#13806): do we need to have a strategy for different variants?
-                .fields(Some(variants.len().wrapping_sub(1))) // choose last variant
-                .iter()
-                .map(value_strategy_with_layout)
-                .collect::<Vec<_>>()
-                .prop_map(move |vals| Value::struct_(Struct::pack(vals)))
-                .boxed(),
+                // Choose the last variant when one exists. An empty variant list
+                // has no legal tag, so generate no fields.
+                let field_layouts = struct_layout
+                    .fields(Some(variants.len().wrapping_sub(1)))
+                    .unwrap_or(&[]);
+                field_layouts
+                    .iter()
+                    .map(value_strategy_with_layout)
+                    .collect::<Vec<_>>()
+                    .prop_map(move |vals| Value::struct_(Struct::pack(vals)))
+                    .boxed()
+            },
 
             L::Struct(struct_layout) => struct_layout
                 .fields(None)
+                .unwrap_or(&[])
                 .iter()
                 .map(value_strategy_with_layout)
                 .collect::<Vec<_>>()
@@ -4896,12 +4911,16 @@ impl ValueImpl {
                 if let Some((tag, variant_layouts)) =
                     try_get_variant_field_layouts(struct_layout, values)
                 {
-                    // This conversion is infallible and only feeds best-effort
-                    // consumers such as `debug::print`. An out-of-range tag
-                    // cannot occur for a well-formed value; if one somehow does,
-                    // fall back to no field layouts rather than panicking. The
-                    // enforced check lives on the BCS serialization path above.
-                    let variant_layouts = variant_layouts.unwrap_or(&[]);
+                    // Best-effort conversion for consumers such as `debug::print`.
+                    // An unknown tag is not a unit variant: collapsing it to
+                    // empty fields would hide the same serialize/deserialize
+                    // hole that BCS serialization already rejects.
+                    let variant_layouts = variant_layouts.unwrap_or_else(|| {
+                        panic!(
+                            "cannot convert value as {:?}: variant tag {} is out of range",
+                            struct_layout, tag
+                        )
+                    });
                     MoveValue::Struct(MoveStruct::new_variant(
                         tag,
                         values
@@ -4913,10 +4932,16 @@ impl ValueImpl {
                             .collect(),
                     ))
                 } else {
+                    let field_layouts = struct_layout.fields(None).unwrap_or_else(|| {
+                        panic!(
+                            "cannot convert value as {:?}: field layouts unavailable",
+                            struct_layout
+                        )
+                    });
                     MoveValue::Struct(MoveStruct::new(
                         values
                             .iter()
-                            .zip(struct_layout.fields(None))
+                            .zip(field_layouts)
                             .map(|(v, field_layout)| v.as_move_value(field_layout))
                             .collect(),
                     ))
@@ -4980,9 +5005,9 @@ fn try_get_variant_field_layouts<'a>(
     layout: &'a MoveStructLayout,
     values: &[ValueImpl],
 ) -> Option<(u16, Option<&'a [MoveTypeLayout]>)> {
-    if let MoveStructLayout::RuntimeVariants(variants) = layout {
+    if matches!(layout, MoveStructLayout::RuntimeVariants(_)) {
         if let Some(ValueImpl::U16(tag)) = values.first() {
-            return Some((*tag, variants.get(*tag as usize).map(Vec::as_slice)));
+            return Some((*tag, layout.fields(Some(*tag as usize))));
         }
     }
     None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Movement [#411](https://github.com/movement-network/aptos-core/pull/411) made BCS serialize reject out-of-range `RuntimeVariants` tags via `try_get_variant_field_layouts`. The layout accessors themselves still returned an empty slice for a bad or missing tag (`fields()` / `into_fields()`), so other walkers could treat that tag as a unit variant.

This is a clean-room completion of the fail-closed layout API (upstream intent only: aptos-labs/aptos-core#20304 `fields() -> Option`). No aptos-labs code was cherry-picked or copied.

`MoveStructLayout::fields` and `into_fields` now return `Option`:

- `Runtime` requires `variant == None`
- `RuntimeVariants` requires `Some(idx)` in range
- decorated layouts are not available through the borrowed `fields()` accessor

**Invariant:** serialization must not emit an unknown variant tag. An empty field list is a valid unit variant (`Some(&[])`). Callers must handle `None` and must not fall back to empty fields.

Call sites updated in `move-vm-types`: BCS serialize, `as_move_value`, delayed-field string/DerivedString layout walks, and the value proptest strategy. Feature flags 81/95 are not enabled.

## How Has This Been Tested?

Verified locally:

```
cargo test -p move-core-types -p move-vm-types
# move-core-types: 51 passed
# move-vm-types: 71 passed
```

New coverage:

- `fields_returns_some_for_consistent_runtime_queries` / `fields_returns_none_for_unknown_or_inconsistent_tags` / `into_fields_is_fail_closed_like_fields`
- existing `enum_out_of_range_variant_tag_is_not_serializable` (#411)
- `as_move_value_rejects_out_of_range_unit_tag`
- delayed-field tests that enum layouts are not mistaken for String / DerivedStringSnapshot

## Key Areas to Review

- `MoveStructLayout::fields` / `into_fields` contract: `None` vs empty unit variant
- Serialize path: `fields(None)` error instead of empty-tuple serialize
- `as_move_value`: panics on unknown tag rather than emitting a unit variant
- Delayed-field `is_string_layout` / `is_derived_string_struct_layout` handle `None`

## Type of Change
- [ ] New feature
- [x] Bug fix
- [x] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [x] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2eb09d16-9355-49aa-b6fb-34616773dedf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2eb09d16-9355-49aa-b6fb-34616773dedf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/movement-network/codesmith/aptos-core/pr/425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791262962&installation_model_id=17568&pr_number=425&repository=movement-network%2Faptos-core&return_to=https%3A%2F%2Fgithub.com%2Fmovement-network%2Faptos-core%2Fpull%2F425&signature=3c5da249e88d359cd166b6dd4c8d84c7355321bcccc133e1468a9c874572e8fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->