### PR TITLE
[vm] Fail closed on aliased RefCell borrows in Move values

### DIFF
--- a/third_party/move/move-vm/types/src/values/value_tests.rs
+++ b/third_party/move/move-vm/types/src/values/value_tests.rs
@@ -5,7 +5,7 @@
 use crate::{loaded_data::runtime_types::TypeBuilder, values::*, views::*};
 use claims::{assert_err, assert_ok};
 use move_binary_format::errors::*;
-use move_core_types::{account_address::AccountAddress, u256::U256};
+use move_core_types::{account_address::AccountAddress, u256::U256, vm_status::StatusCode};
 
 #[test]
 fn locals() -> PartialVMResult<()> {
@@ -306,6 +306,68 @@ fn test_mem_swap() -> PartialVMResult<()> {
             }
         }
     }
+
+    Ok(())
+}
+
+fn assert_invariant_violation(err: PartialVMError) {
+    assert_eq!(
+        err.major_status(),
+        StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR
+    );
+}
+
+/// Two `Reference`s into the same container must not panic the VM thread.
+/// `swap_contents` fails closed with an invariant-violation status.
+#[test]
+fn container_self_swap_returns_status_instead_of_panicking() -> PartialVMResult<()> {
+    let mut locals = Locals::new(3);
+    locals.store_loc(0, Value::vector_u64(vec![1, 2, 3]), false)?;
+    locals.store_loc(1, Value::struct_(Struct::pack(vec![Value::u16(9)])), false)?;
+    locals.store_loc(
+        2,
+        Value::vector_for_testing_only(vec![Value::u64(7), Value::u64(8)]),
+        false,
+    )?;
+
+    let borrow =
+        |ls: &Locals, idx: usize| ls.borrow_loc(idx).unwrap().value_as::<Reference>().unwrap();
+
+    for idx in 0..3 {
+        let before = borrow(&locals, idx).read_ref()?;
+        let err = borrow(&locals, idx)
+            .swap_values(borrow(&locals, idx))
+            .unwrap_err();
+        assert_invariant_violation(err);
+        assert!(borrow(&locals, idx).read_ref()?.equals(&before)?);
+    }
+
+    Ok(())
+}
+
+/// `move_range` on two refs to the same vector must not panic. Distinct
+/// vectors still transfer the range.
+#[test]
+fn move_range_on_aliased_vector_refs_returns_status_instead_of_panicking() -> PartialVMResult<()> {
+    let mut locals = Locals::new(2);
+    locals.store_loc(0, Value::vector_u64(vec![10, 20, 30]), false)?;
+    locals.store_loc(1, Value::vector_u64(vec![40, 50]), false)?;
+
+    let ty = TypeBuilder::with_limits(10, 10).create_u64_ty();
+    let as_vector_ref =
+        |ls: &Locals, idx: usize| ls.borrow_loc(idx).unwrap().value_as::<VectorRef>().unwrap();
+
+    let src = as_vector_ref(&locals, 0);
+    let dst = as_vector_ref(&locals, 1);
+    assert_ok!(VectorRef::move_range(&src, 0, 1, &dst, 0, &ty));
+    assert_eq!(src.length_as_usize(&ty)?, 2);
+    assert_eq!(dst.length_as_usize(&ty)?, 3);
+
+    let same_a = as_vector_ref(&locals, 0);
+    let same_b = as_vector_ref(&locals, 0);
+    let err = VectorRef::move_range(&same_a, 0, 1, &same_b, 0, &ty).unwrap_err();
+    assert_invariant_violation(err);
+    assert_eq!(same_a.length_as_usize(&ty)?, 2);
 
     Ok(())
 }

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -33,7 +33,7 @@ use serde::{
     Deserialize,
 };
 use std::{
-    cell::RefCell,
+    cell::{RefCell, RefMut},
     cmp::Ordering,
     fmt::{self, Debug, Display, Formatter},
     iter, mem,
@@ -334,6 +334,33 @@ fn take_unique_ownership<T: Debug>(r: Rc<RefCell<T>>) -> PartialVMResult<T> {
                 .with_sub_status(move_core_types::vm_status::sub_status::unknown_invariant_violation::EREFERENCE_COUNTING_FAILURE),
         ),
     }
+}
+
+/// Fail-closed exclusive access to two `RefCell`s that the bytecode verifier
+/// promises are distinct.
+///
+/// Invariant: a broken aliasing (or already-borrowed) pair must surface as
+/// `UNKNOWN_INVARIANT_VIOLATION_ERROR`. Never call stacked `borrow_mut` on
+/// the pair — that panics the interpreter thread instead of producing a
+/// catchable VM status.
+fn exclusive_cell_pair<'a, T>(
+    left: &'a Rc<RefCell<T>>,
+    right: &'a Rc<RefCell<T>>,
+) -> PartialVMResult<(RefMut<'a, T>, RefMut<'a, T>)> {
+    if Rc::ptr_eq(left, right) {
+        return Err(overlapping_mut_cells());
+    }
+    let left_mut = left.try_borrow_mut().map_err(|_| overlapping_mut_cells())?;
+    let right_mut = right
+        .try_borrow_mut()
+        .map_err(|_| overlapping_mut_cells())?;
+    Ok((left_mut, right_mut))
+}
+
+fn overlapping_mut_cells() -> PartialVMError {
+    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(
+        "cannot take exclusive RefCell access on overlapping or already-borrowed cells".to_string(),
+    )
 }
 
 impl ContainerRef {
@@ -1294,44 +1321,45 @@ impl_vm_value_from_primitive!(AccountAddress, Address);
  *
  *************************************************************************************/
 impl Container {
-    /// Swaps contents of two mutable references.
+    /// Exchange the inner buffers of two containers.
     ///
-    /// Precondition for this funciton is that `self` and `other` are required to be
-    /// distinct references.
-    /// Move will guarantee that invariant, because it prevents from having two
-    /// mutable references to the same value.
+    /// Move's reference safety requires `self` and `other` to name distinct
+    /// cells. If that invariant is broken, this method returns an invariant-
+    /// violation status instead of panicking on a stacked `borrow_mut`.
     fn swap_contents(&self, other: &Self) -> PartialVMResult<()> {
         use Container::*;
 
+        fn swap_cells<T>(left: &Rc<RefCell<T>>, right: &Rc<RefCell<T>>) -> PartialVMResult<()> {
+            let (mut a, mut b) = exclusive_cell_pair(left, right)?;
+            mem::swap(&mut *a, &mut *b);
+            Ok(())
+        }
+
         match (self, other) {
-            (Vec(l), Vec(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
-            (Struct(l), Struct(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
+            (Vec(l), Vec(r)) => swap_cells(l, r),
+            (Struct(l), Struct(r)) => swap_cells(l, r),
 
-            (VecBool(l), VecBool(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
-            (VecAddress(l), VecAddress(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
+            (VecBool(l), VecBool(r)) => swap_cells(l, r),
+            (VecAddress(l), VecAddress(r)) => swap_cells(l, r),
 
-            (VecU8(l), VecU8(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
-            (VecU16(l), VecU16(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
-            (VecU32(l), VecU32(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
-            (VecU64(l), VecU64(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
-            (VecU128(l), VecU128(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
-            (VecU256(l), VecU256(r)) => mem::swap(&mut *l.borrow_mut(), &mut *r.borrow_mut()),
+            (VecU8(l), VecU8(r)) => swap_cells(l, r),
+            (VecU16(l), VecU16(r)) => swap_cells(l, r),
+            (VecU32(l), VecU32(r)) => swap_cells(l, r),
+            (VecU64(l), VecU64(r)) => swap_cells(l, r),
+            (VecU128(l), VecU128(r)) => swap_cells(l, r),
+            (VecU256(l), VecU256(r)) => swap_cells(l, r),
 
             (
                 Locals(_) | Vec(_) | Struct(_) | VecBool(_) | VecAddress(_) | VecU8(_) | VecU16(_)
                 | VecU32(_) | VecU64(_) | VecU128(_) | VecU256(_),
                 _,
-            ) => {
-                return Err(
-                    PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR).with_message(format!(
-                        "cannot swap container values: {:?}, {:?}",
-                        self, other
-                    )),
-                )
-            },
+            ) => Err(
+                PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR).with_message(format!(
+                    "cannot swap container values: {:?}, {:?}",
+                    self, other
+                )),
+            ),
         }
-
-        Ok(())
     }
 }
 
@@ -2891,8 +2919,9 @@ impl VectorRef {
     /// In the `to` vector, elements after the `insert_position` are moved to the right to make space for new elements
     /// (i.e. range is inserted, while the order of the rest of the elements is kept).
     ///
-    /// Precondition for this function is that `from` and `to` vectors are required to be distinct
-    /// Move will guaranteee that invariant, because it prevents from having two mutable references to the same value.
+    /// `from` and `to` must be distinct cells. The verifier enforces that; if
+    /// the pair aliases we fail closed with an invariant-violation status
+    /// rather than panicking on stacked `borrow_mut`.
     pub fn move_range(
         from_self: &Self,
         removal_position: usize,
@@ -2913,8 +2942,7 @@ impl VectorRef {
 
         macro_rules! move_range {
             ($from:expr, $to:expr) => {{
-                let mut from_v = $from.borrow_mut();
-                let mut to_v = $to.borrow_mut();
+                let (mut from_v, mut to_v) = exclusive_cell_pair($from, $to)?;
 
                 if removal_position.checked_add(length).map_or(true, |end| end > from_v.len())
                         || insert_position > to_v.len() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Clean-room rewrite (not a cherry-pick or copy of aptos-labs sources). Intent only: aliased paired `RefCell::borrow_mut` must not abort the interpreter thread (aptos-labs/aptos-core#20439).

`Container::swap_contents` and `VectorRef::move_range` took two exclusive `borrow_mut`s. Move's borrow checker promises the cells are distinct; if that invariant is broken, stacked `borrow_mut` panicked the VM thread.

This change acquires the pair through a new helper, `exclusive_cell_pair`:

1. Reject `Rc::ptr_eq` immediately.
2. Otherwise `try_borrow_mut` each cell.
3. On either failure, return `UNKNOWN_INVARIANT_VIOLATION_ERROR`.

Verified distinct cells still swap / move as before. No other crate in the monorepo is touched.

**Invariant:** a broken aliasing (or already-borrowed) pair on these paths surfaces as a catchable VM status, never a Rust panic.

Follows `SECURITY.md` / `RUST_SECURE_CODING.md`: `Result` instead of panic, documented safety invariant, no `unsafe`.

## How Has This Been Tested?

- `cargo test -p move-vm-types` — **70 passed, 0 failed**
- `container_self_swap_returns_status_instead_of_panicking` — specialized vector, generic struct, generic vector; self-swap is `UNKNOWN_INVARIANT_VIOLATION_ERROR` and leaves contents unchanged
- `move_range_on_aliased_vector_refs_returns_status_instead_of_panicking` — distinct vectors still transfer; aliased refs return the same status
- Existing `test_mem_swap` covers the happy path for distinct container refs

## Key Areas to Review

- `exclusive_cell_pair` in `third_party/move/move-vm/types/src/values/values_impl.rs` — fail-closed helper used by both hardened paths
- Confirm this is an independent rewrite (helper + `ptr_eq` first, not a port of the upstream patch)

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dfdb55b1-4d1d-428e-a29c-a0140f774e1c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dfdb55b1-4d1d-428e-a29c-a0140f774e1c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/movement-network/codesmith/aptos-core/pr/426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791262989&installation_model_id=17568&pr_number=426&repository=movement-network%2Faptos-core&return_to=https%3A%2F%2Fgithub.com%2Fmovement-network%2Faptos-core%2Fpull%2F426&signature=d2b8dccd5e47c869d5e55633d6cec6cc9e3c4a1d804c0b59b2300fe3a48b1048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->