### PR TITLE
Match commit votes against the full LedgerInfo

### DIFF
--- a/consensus/consensus-types/src/order_vote.rs
+++ b/consensus/consensus-types/src/order_vote.rs
@@ -4,7 +4,7 @@
 
 use crate::common::Author;
 use anyhow::{ensure, Context};
-use aptos_crypto::{bls12381, HashValue};
+use aptos_crypto::{bls12381, CryptoMaterialError, HashValue};
 use aptos_short_hex_str::AsShortHexStr;
 use aptos_types::{
     ledger_info::{LedgerInfo, SignatureWithStatus},
@@ -63,8 +63,8 @@ impl OrderVote {
         &self.ledger_info
     }
 
-    pub fn signature(&self) -> &bls12381::Signature {
-        self.signature.signature()
+    pub fn signature(&self) -> Result<bls12381::Signature, CryptoMaterialError> {
+        self.signature.recover_group_element()
     }
 
     // Question: SignatureWithStatus has interior mutability. Is it okay to expose this?

--- a/consensus/consensus-types/src/pipeline/commit_vote.rs
+++ b/consensus/consensus-types/src/pipeline/commit_vote.rs
@@ -79,6 +79,13 @@ impl CommitVote {
         &self.ledger_info
     }
 
+    /// Whether this vote is a signature over `expected` in full (`commit_info`
+    /// and `consensus_data_hash`). Partial-proof aggregation must use this,
+    /// not `commit_info` alone.
+    pub fn signs_same_ledger_info(&self, expected: &LedgerInfo) -> bool {
+        &self.ledger_info == expected
+    }
+
     /// Recover the group element of the commit-vote signature.
     /// LedgerInfo matching must use [`Self::ledger_info`] / [`Self::signature_with_status`].
     pub fn signature(&self) -> Result<bls12381::Signature, CryptoMaterialError> {
@@ -100,8 +107,10 @@ impl CommitVote {
         self.ledger_info.epoch()
     }
 
-    /// Verifies that the consensus data hash of LedgerInfo corresponds to the commit proposal,
-    /// and then verifies the signature.
+    /// Checks that `sender` is the vote author and that the signature is valid
+    /// for *this* vote's `ledger_info`. That does not bind the vote to any
+    /// other node's commit message: a partial proof must still compare the
+    /// entire `LedgerInfo` before inserting the signature.
     pub fn verify(&self, sender: Author, validator: &ValidatorVerifier) -> anyhow::Result<()> {
         ensure!(
             self.author() == sender,
@@ -116,5 +125,23 @@ impl CommitVote {
 
     pub fn commit_info(&self) -> &BlockInfo {
         self.ledger_info().commit_info()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aptos_crypto::HashValue;
+
+    #[test]
+    fn signs_same_ledger_info_requires_consensus_data_hash() {
+        let signer = ValidatorSigner::random([7; 32]);
+        let commit = BlockInfo::empty();
+        let expected = LedgerInfo::new(commit.clone(), HashValue::zero());
+        let other = LedgerInfo::new(commit, HashValue::from_u64(9));
+        let vote = CommitVote::new(signer.author(), other, &signer).unwrap();
+        assert_eq!(vote.commit_info(), expected.commit_info());
+        assert!(!vote.signs_same_ledger_info(&expected));
+        assert!(vote.signs_same_ledger_info(vote.ledger_info()));
     }
 }

--- a/consensus/consensus-types/src/pipeline/commit_vote.rs
+++ b/consensus/consensus-types/src/pipeline/commit_vote.rs
@@ -79,9 +79,10 @@ impl CommitVote {
         &self.ledger_info
     }
 
-    /// Return the signature of the vote
-    pub fn signature(&self) -> &bls12381::Signature {
-        self.signature.signature()
+    /// Recover the group element of the commit-vote signature.
+    /// LedgerInfo matching must use [`Self::ledger_info`] / [`Self::signature_with_status`].
+    pub fn signature(&self) -> Result<bls12381::Signature, CryptoMaterialError> {
+        self.signature.recover_group_element()
     }
 
     /// Returns the signature along with the verification status of the signature.

--- a/consensus/consensus-types/src/proof_of_store.rs
+++ b/consensus/consensus-types/src/proof_of_store.rs
@@ -280,8 +280,8 @@ impl SignedBatchInfo {
         Ok(validator.optimistic_verify(self.signer, &self.info, &self.signature)?)
     }
 
-    pub fn signature(&self) -> &bls12381::Signature {
-        self.signature.signature()
+    pub fn signature(&self) -> Result<bls12381::Signature, CryptoMaterialError> {
+        self.signature.recover_group_element()
     }
 
     pub fn signature_with_status(&self) -> &SignatureWithStatus {

--- a/consensus/consensus-types/src/vote.rs
+++ b/consensus/consensus-types/src/vote.rs
@@ -108,9 +108,10 @@ impl Vote {
         &self.ledger_info
     }
 
-    /// Return the signature of the vote
-    pub fn signature(&self) -> &bls12381::Signature {
-        self.signature.signature()
+    /// Recover the group element of the vote signature.
+    /// Callers that only match `LedgerInfo` should use [`Self::signature_with_status`].
+    pub fn signature(&self) -> Result<bls12381::Signature, CryptoMaterialError> {
+        self.signature.recover_group_element()
     }
 
     pub fn signature_with_status(&self) -> &SignatureWithStatus {

--- a/consensus/safety-rules/src/test_utils.rs
+++ b/consensus/safety-rules/src/test_utils.rs
@@ -173,7 +173,7 @@ pub fn make_proposal_with_parent_and_overrides(
         PartialSignatures::empty(),
     );
 
-    ledger_info_with_signatures.add_signature(vote.author(), vote.signature().clone());
+    ledger_info_with_signatures.add_signature(vote.author(), vote.signature().unwrap());
 
     let qc = QuorumCert::new(
         vote_data,

--- a/consensus/src/pending_order_votes.rs
+++ b/consensus/src/pending_order_votes.rs
@@ -288,14 +288,14 @@ mod tests {
             li.clone(),
             signers[0].sign(&li).expect("Unable to sign ledger info"),
         );
-        partial_signatures.add_signature(signers[0].author(), vote_0.signature().clone());
+        partial_signatures.add_signature(signers[0].author(), vote_0.signature().unwrap());
 
         let vote_1 = OrderVote::new_with_signature(
             signers[1].author(),
             li.clone(),
             signers[1].sign(&li).expect("Unable to sign ledger info"),
         );
-        partial_signatures.add_signature(signers[1].author(), vote_1.signature().clone());
+        partial_signatures.add_signature(signers[1].author(), vote_1.signature().unwrap());
 
         let vote_2 = OrderVote::new_with_signature(
             signers[2].author(),
@@ -308,7 +308,7 @@ mod tests {
             li.clone(),
             signers[3].sign(&li).expect("Unable to sign ledger info"),
         );
-        partial_signatures.add_signature(signers[3].author(), vote_3.signature().clone());
+        partial_signatures.add_signature(signers[3].author(), vote_3.signature().unwrap());
 
         let vote_4 = OrderVote::new_with_signature(
             signers[4].author(),

--- a/consensus/src/pending_votes.rs
+++ b/consensus/src/pending_votes.rs
@@ -717,7 +717,7 @@ mod tests {
             pending_votes.insert_vote(&vote_0, &validator_verifier),
             VoteReceptionResult::VoteAdded(1)
         );
-        partial_sigs.add_signature(signers[0].author(), vote_0.signature().clone());
+        partial_sigs.add_signature(signers[0].author(), vote_0.signature().unwrap());
 
         // same author voting for the same thing -> DuplicateVote
         assert_eq!(
@@ -729,7 +729,7 @@ mod tests {
             pending_votes.insert_vote(&vote_1, &validator_verifier),
             VoteReceptionResult::VoteAdded(2)
         );
-        partial_sigs.add_signature(signers[1].author(), vote_1.signature().clone());
+        partial_sigs.add_signature(signers[1].author(), vote_1.signature().unwrap());
 
         assert_eq!(validator_verifier.pessimistic_verify_set().len(), 0);
 
@@ -750,7 +750,7 @@ mod tests {
             },
         }
 
-        partial_sigs.add_signature(signers[3].author(), vote_3.signature().clone());
+        partial_sigs.add_signature(signers[3].author(), vote_3.signature().unwrap());
         let aggregated_sig = validator_verifier
             .aggregate_signatures(partial_sigs.signatures_iter())
             .unwrap();

--- a/consensus/src/pipeline/buffer_item.rs
+++ b/consensus/src/pipeline/buffer_item.rs
@@ -548,23 +548,23 @@ mod test {
         let mut partial_signatures = BTreeMap::new();
         partial_signatures.insert(
             validator_signers[0].author(),
-            commit_votes[0].signature().clone(),
+            commit_votes[0].signature().unwrap(),
         );
         partial_signatures.insert(
             validator_signers[1].author(),
-            commit_votes[1].signature().clone(),
+            commit_votes[1].signature().unwrap(),
         );
         partial_signatures.insert(
             validator_signers[2].author(),
-            commit_votes[2].signature().clone(),
+            commit_votes[2].signature().unwrap(),
         );
         partial_signatures.insert(
             validator_signers[3].author(),
-            commit_votes[3].signature().clone(),
+            commit_votes[3].signature().unwrap(),
         );
         partial_signatures.insert(
             validator_signers[4].author(),
-            commit_votes[4].signature().clone(),
+            commit_votes[4].signature().unwrap(),
         );
         let li_with_sig = validator_verifier
             .aggregate_signatures(partial_signatures.iter())
@@ -653,23 +653,23 @@ mod test {
         let mut partial_signatures = BTreeMap::new();
         partial_signatures.insert(
             validator_signers[0].author(),
-            commit_votes[0].signature().clone(),
+            commit_votes[0].signature().unwrap(),
         );
         partial_signatures.insert(
             validator_signers[1].author(),
-            commit_votes[1].signature().clone(),
+            commit_votes[1].signature().unwrap(),
         );
         partial_signatures.insert(
             validator_signers[2].author(),
-            commit_votes[2].signature().clone(),
+            commit_votes[2].signature().unwrap(),
         );
         partial_signatures.insert(
             validator_signers[4].author(),
-            commit_votes[4].signature().clone(),
+            commit_votes[4].signature().unwrap(),
         );
         partial_signatures.insert(
             validator_signers[6].author(),
-            commit_votes[6].signature().clone(),
+            commit_votes[6].signature().unwrap(),
         );
         let li_with_sig = validator_verifier
             .aggregate_signatures(partial_signatures.iter())

--- a/consensus/src/pipeline/buffer_item.rs
+++ b/consensus/src/pipeline/buffer_item.rs
@@ -5,7 +5,7 @@
 use crate::{
     counters, pipeline::hashable::Hashable, state_replication::StateComputerCommitCallBackType,
 };
-use anyhow::anyhow;
+use anyhow::{anyhow, ensure};
 use aptos_consensus_types::{
     common::{Author, Round},
     pipeline::commit_vote::CommitVote,
@@ -393,47 +393,60 @@ impl BufferItem {
     }
 
     pub fn add_signature_if_matched(&mut self, vote: CommitVote) -> anyhow::Result<()> {
-        let target_commit_info = vote.commit_info();
-        let author = vote.author();
-        let signature = vote.signature_with_status();
         match self {
             Self::Ordered(ordered) => {
+                // Execution has not produced the final LedgerInfo yet, so only
+                // the ordered BlockInfo can be compared. Votes stay in
+                // `unverified_votes` (one per author) and
+                // `create_signature_aggregator` later admits a vote only when
+                // its entire LedgerInfo equals the executed commit message.
                 if ordered
                     .ordered_proof
                     .commit_info()
-                    .match_ordered_only(target_commit_info)
+                    .match_ordered_only(vote.commit_info())
                 {
-                    // we optimistically assume the vote will be valid in the future.
-                    // when advancing to executed item, we will check if the sigs are valid.
-                    // each author at most stores a single sig for each item,
-                    // so an adversary will not be able to flood our memory.
-                    ordered.unverified_votes.insert(author, vote);
+                    ordered.unverified_votes.insert(vote.author(), vote);
                     return Ok(());
                 }
             },
             Self::Executed(executed) => {
-                if executed.commit_info == *target_commit_info {
-                    executed
-                        .partial_commit_proof
-                        .add_signature(author, signature);
-                    return Ok(());
-                }
+                return Self::admit_into_partial_commit_proof(
+                    &mut executed.partial_commit_proof,
+                    &vote,
+                );
             },
             Self::Signed(signed) => {
-                if signed.partial_commit_proof.data().commit_info() == target_commit_info {
-                    signed.partial_commit_proof.add_signature(author, signature);
-                    return Ok(());
-                }
+                return Self::admit_into_partial_commit_proof(
+                    &mut signed.partial_commit_proof,
+                    &vote,
+                );
             },
             Self::Aggregated(aggregated) => {
-                // we do not need to do anything for aggregated
-                // but return true is helpful to stop the outer loop early
-                if aggregated.commit_proof.commit_info() == target_commit_info {
+                // Already certified. Accept only a vote bound to that same
+                // LedgerInfo so a foreign consensus_data_hash cannot ACK.
+                if vote.signs_same_ledger_info(aggregated.commit_proof.ledger_info()) {
                     return Ok(());
                 }
             },
         }
-        Err(anyhow!("Inconsistent commit info."))
+        Err(anyhow!(
+            "commit vote is not bound to this buffer item's LedgerInfo"
+        ))
+    }
+
+    /// Admit `vote` into a partial proof only when it signed the exact
+    /// LedgerInfo the aggregator is collecting. `commit_info` equality is
+    /// not enough: BLS is bound to `commit_info` plus `consensus_data_hash`.
+    fn admit_into_partial_commit_proof(
+        partial: &mut SignatureAggregator<LedgerInfo>,
+        vote: &CommitVote,
+    ) -> anyhow::Result<()> {
+        ensure!(
+            vote.signs_same_ledger_info(partial.data()),
+            "commit vote LedgerInfo does not match the partial commit proof"
+        );
+        partial.add_signature(vote.author(), vote.signature_with_status());
+        Ok(())
     }
 
     pub fn is_ordered(&self) -> bool {
@@ -597,9 +610,10 @@ mod test {
 
         match executed_item {
             BufferItem::Executed(ref executed_item_inner) => {
-                assert_eq!(executed_item_inner.executed_blocks, vec![
-                    pipelined_block.clone()
-                ]);
+                assert_eq!(
+                    executed_item_inner.executed_blocks,
+                    vec![pipelined_block.clone()]
+                );
                 assert_eq!(executed_item_inner.commit_info, block_info);
                 assert_eq!(
                     executed_item_inner
@@ -703,9 +717,10 @@ mod test {
 
         match executed_item {
             BufferItem::Executed(ref executed_item_inner) => {
-                assert_eq!(executed_item_inner.executed_blocks, vec![
-                    pipelined_block.clone()
-                ]);
+                assert_eq!(
+                    executed_item_inner.executed_blocks,
+                    vec![pipelined_block.clone()]
+                );
                 assert_eq!(executed_item_inner.commit_info, block_info);
                 assert_eq!(
                     executed_item_inner
@@ -726,9 +741,10 @@ mod test {
         let mut executed_item = executed_item.try_advance_to_aggregated(&validator_verifier);
         match executed_item {
             BufferItem::Executed(ref executed_item_inner) => {
-                assert_eq!(executed_item_inner.executed_blocks, vec![
-                    pipelined_block.clone()
-                ]);
+                assert_eq!(
+                    executed_item_inner.executed_blocks,
+                    vec![pipelined_block.clone()]
+                );
                 assert_eq!(executed_item_inner.commit_info, block_info);
                 assert_eq!(
                     executed_item_inner
@@ -750,9 +766,10 @@ mod test {
         let mut executed_item = executed_item.try_advance_to_aggregated(&validator_verifier);
         match executed_item {
             BufferItem::Executed(ref executed_item_inner) => {
-                assert_eq!(executed_item_inner.executed_blocks, vec![
-                    pipelined_block.clone()
-                ]);
+                assert_eq!(
+                    executed_item_inner.executed_blocks,
+                    vec![pipelined_block.clone()]
+                );
                 assert_eq!(executed_item_inner.commit_info, block_info);
                 assert_eq!(
                     executed_item_inner
@@ -777,6 +794,91 @@ mod test {
                 assert_eq!(aggregated_item_inner.commit_proof, commit_proof);
             },
             _ => panic!("Expected aggregated item."),
+        }
+    }
+
+    /// A BLS commit vote is bound to the entire LedgerInfo. Same `commit_info`
+    /// with a different `consensus_data_hash` must not enter a partial proof,
+    /// even when `CommitVote::verify` succeeds against the voter's own message.
+    /// Honest votes over the expected LedgerInfo must still form a certificate.
+    #[test]
+    fn reject_vote_with_unrelated_consensus_data_hash_and_still_quorum() {
+        let (validator_signers, validator_verifier) = create_validators();
+        let pipelined_block = create_pipelined_block();
+        let block_info = pipelined_block.block_info();
+        let expected_ledger = LedgerInfo::new(block_info.clone(), HashValue::zero());
+        let foreign_ledger = LedgerInfo::new(block_info.clone(), HashValue::from_u64(0xA11CE));
+        let ordered_proof =
+            LedgerInfoWithSignatures::new(expected_ledger.clone(), AggregateSignature::empty());
+
+        let mut executed_item = BufferItem::new_ordered(
+            vec![pipelined_block.clone()],
+            ordered_proof,
+            Box::new(move |_, _| {}),
+            HashMap::new(),
+        )
+        .advance_to_executed_or_aggregated(
+            vec![pipelined_block.clone()],
+            &validator_verifier,
+            None,
+            true,
+        );
+        assert!(executed_item.is_executed());
+
+        let foreign_vote = CommitVote::new(
+            validator_signers[0].author(),
+            foreign_ledger.clone(),
+            &validator_signers[0],
+        )
+        .unwrap();
+        assert_eq!(foreign_vote.commit_info(), expected_ledger.commit_info());
+        assert_ne!(foreign_vote.ledger_info(), &expected_ledger);
+        assert!(!foreign_vote.signs_same_ledger_info(&expected_ledger));
+        foreign_vote
+            .verify(validator_signers[0].author(), &validator_verifier)
+            .expect("signature is valid over the foreign LedgerInfo");
+        assert!(
+            executed_item
+                .add_signature_if_matched(foreign_vote.clone())
+                .is_err(),
+            "Executed partial proof must reject a vote bound to another consensus_data_hash"
+        );
+        match &executed_item {
+            BufferItem::Executed(inner) => {
+                assert_eq!(inner.partial_commit_proof.all_voters().count(), 0);
+            },
+            _ => panic!("Expected executed item after rejected vote"),
+        }
+
+        let signed_item = executed_item.advance_to_signed(
+            validator_signers[1].author(),
+            validator_signers[1].sign(&expected_ledger).unwrap(),
+        );
+        let mut signed_item = signed_item;
+        assert!(
+            signed_item.add_signature_if_matched(foreign_vote).is_err(),
+            "Signed partial proof must reject a vote bound to another consensus_data_hash"
+        );
+
+        let honest_votes =
+            create_valid_commit_votes(validator_signers.clone(), expected_ledger.clone());
+        for vote in honest_votes.iter().take(5) {
+            signed_item
+                .add_signature_if_matched(vote.clone())
+                .expect("honest vote over the expected LedgerInfo must be admitted");
+        }
+
+        let aggregated_item = signed_item.try_advance_to_aggregated(&validator_verifier);
+        match aggregated_item {
+            BufferItem::Aggregated(inner) => {
+                inner
+                    .commit_proof
+                    .verify_signatures(&validator_verifier)
+                    .expect("honest quorum must produce a verifiable commit certificate");
+                assert_eq!(inner.commit_proof.ledger_info(), &expected_ledger);
+                assert!(inner.commit_proof.get_num_voters() >= 5);
+            },
+            _ => panic!("Expected aggregated item from honest quorum"),
         }
     }
 }

--- a/consensus/src/pipeline/signing_phase.rs
+++ b/consensus/src/pipeline/signing_phase.rs
@@ -85,8 +85,11 @@ impl StatelessPipeline for SigningPhase {
             fut.commit_vote_fut
                 .clone()
                 .await
-                .map(|vote| vote.signature().clone())
                 .map_err(|e| Error::InternalError(e.to_string()))
+                .and_then(|vote| {
+                    vote.signature()
+                        .map_err(|e| Error::InternalError(e.to_string()))
+                })
         } else {
             self.safety_rule_handle
                 .sign_commit_vote(ordered_ledger_info, commit_ledger_info.clone())

--- a/types/src/aggregate_signature.rs
+++ b/types/src/aggregate_signature.rs
@@ -1,8 +1,9 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::wire_bls::WireBlsSignature;
 use aptos_bitvec::BitVec;
-use aptos_crypto::bls12381;
+use aptos_crypto::{bls12381, CryptoMaterialError};
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use move_core_types::account_address::AccountAddress;
 use serde::{Deserialize, Serialize};
@@ -12,10 +13,14 @@ use std::collections::BTreeMap;
 /// it stores a bit mask representing the set of validators participating in the signing process
 /// and the multi-signature/aggregated signature itself,
 /// which was aggregated from these validators' partial BLS signatures.
+///
+/// The signature payload stays in compressed wire form so a later
+/// `LedgerInfo` equality check can inspect bitmask and commit info without
+/// paying G2 decompression. Verification paths call [`Self::try_group_element`].
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, CryptoHasher, BCSCryptoHash)]
 pub struct AggregateSignature {
     validator_bitmask: BitVec,
-    sig: Option<bls12381::Signature>,
+    sig: Option<WireBlsSignature>,
 }
 
 impl AggregateSignature {
@@ -25,7 +30,7 @@ impl AggregateSignature {
     ) -> Self {
         Self {
             validator_bitmask,
-            sig: aggregated_signature,
+            sig: aggregated_signature.map(WireBlsSignature::from),
         }
     }
 
@@ -61,8 +66,26 @@ impl AggregateSignature {
         self.validator_bitmask.count_ones() as usize
     }
 
-    pub fn sig(&self) -> &Option<bls12381::Signature> {
-        &self.sig
+    /// Compressed payload, if present. Does not recover a group element.
+    pub fn wire_sig(&self) -> Option<&WireBlsSignature> {
+        self.sig.as_ref()
+    }
+
+    /// Recover the aggregated group element. `Ok(None)` means no signature
+    /// was stored; `Err` means the 96-byte payload is not a G2 point.
+    pub fn try_group_element(&self) -> Result<Option<bls12381::Signature>, CryptoMaterialError> {
+        match self.sig {
+            None => Ok(None),
+            Some(wire) => wire.recover_group_element().map(Some),
+        }
+    }
+
+    /// Historical accessor. Recovers the group element when the payload is a
+    /// valid point; unrecoverable 96-byte payloads are reported as `None`.
+    /// Verify paths should prefer [`Self::try_group_element`] to distinguish
+    /// "missing" from "malformed".
+    pub fn sig(&self) -> Option<bls12381::Signature> {
+        self.try_group_element().ok().flatten()
     }
 }
 

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -11,10 +11,12 @@ use crate::{
     on_chain_config::ValidatorSet,
     transaction::Version,
     validator_verifier::{ValidatorVerifier, VerifyError},
+    wire_bls::WireBlsSignature,
 };
 use aptos_crypto::{
     bls12381,
     hash::{CryptoHash, HashValue},
+    CryptoMaterialError,
 };
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use derivative::Derivative;
@@ -405,7 +407,9 @@ impl LedgerInfoWithVerifiedSignatures {
 #[derive(Clone, Debug, Derivative)]
 #[derivative(PartialEq, Eq)]
 pub struct SignatureWithStatus {
-    signature: bls12381::Signature,
+    /// Compressed encoding. Equality is on these bytes, matching the old
+    /// `bls12381::Signature` `PartialEq` (which compared `to_bytes()`).
+    signature: WireBlsSignature,
     #[derivative(PartialEq = "ignore")]
     // false if the signature not verified.
     // true if the signature is verified.
@@ -417,13 +421,25 @@ impl SignatureWithStatus {
         self.verification_status.store(true, Ordering::SeqCst);
     }
 
-    pub fn signature(&self) -> &bls12381::Signature {
+    /// Compressed payload. Safe to call while matching commit votes to a
+    /// later full `LedgerInfo`; does not decompress.
+    pub fn wire_signature(&self) -> &WireBlsSignature {
         &self.signature
+    }
+
+    /// Recover the group element. Call this only on verify / aggregate paths.
+    pub fn recover_group_element(&self) -> Result<bls12381::Signature, CryptoMaterialError> {
+        self.signature.recover_group_element()
+    }
+
+    /// Historical name for the recovered group element.
+    pub fn signature(&self) -> Result<bls12381::Signature, CryptoMaterialError> {
+        self.recover_group_element()
     }
 
     pub fn from(signature: bls12381::Signature) -> Self {
         Self {
-            signature,
+            signature: WireBlsSignature::from(signature),
             verification_status: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -447,8 +463,11 @@ impl<'de> Deserialize<'de> for SignatureWithStatus {
     where
         D: serde::Deserializer<'de>,
     {
-        let signature = bls12381::Signature::deserialize(deserializer)?;
-        Ok(SignatureWithStatus::from(signature))
+        let signature = WireBlsSignature::deserialize(deserializer)?;
+        Ok(SignatureWithStatus {
+            signature,
+            verification_status: Arc::new(AtomicBool::new(false)),
+        })
     }
 }
 
@@ -521,11 +540,19 @@ impl<T: Clone + Send + Sync + Serialize + CryptoHash> SignatureAggregator<T> {
     ) -> Result<AggregateSignature, VerifyError> {
         self.check_voting_power(verifier, true)?;
 
-        let all_signatures = self
+        // Skip payloads that are not G2 points. `check_voting_power` still
+        // counted every stored voter; verification of the resulting bitmask
+        // (or a later filter pass) drops the unrecoverable authors.
+        let recovered: Vec<(AccountAddress, bls12381::Signature)> = self
             .signatures
             .iter()
-            .map(|(voter, sig)| (voter, sig.signature()));
-        verifier.aggregate_signatures(all_signatures)
+            .filter_map(|(voter, sig)| {
+                sig.recover_group_element()
+                    .ok()
+                    .map(|point| (*voter, point))
+            })
+            .collect();
+        verifier.aggregate_signatures(recovered.iter().map(|(voter, sig)| (voter, sig)))
     }
 
     fn filter_invalid_signatures(&mut self, verifier: &ValidatorVerifier) {
@@ -611,11 +638,11 @@ mod tests {
     fn test_signature_with_status_bcs() {
         let signature = bls12381::Signature::dummy_signature();
         let signature_with_status_1 = SignatureWithStatus {
-            signature: signature.clone(),
+            signature: WireBlsSignature::from(&signature),
             verification_status: Arc::new(AtomicBool::new(true)),
         };
         let signature_with_status_2 = SignatureWithStatus {
-            signature: signature.clone(),
+            signature: WireBlsSignature::from(&signature),
             verification_status: Arc::new(AtomicBool::new(false)),
         };
         let serialized_signature_with_status_1 =
@@ -623,11 +650,18 @@ mod tests {
         let serialized_signature_with_status_2 =
             bcs::to_bytes(&signature_with_status_2).expect("Failed to serialize signature");
         assert!(serialized_signature_with_status_1 == serialized_signature_with_status_2);
+        assert_eq!(
+            serialized_signature_with_status_1,
+            bcs::to_bytes(&signature).expect("Failed to serialize raw signature")
+        );
 
         let deserialized_signature_with_status: SignatureWithStatus =
             bcs::from_bytes(&serialized_signature_with_status_1)
                 .expect("Failed to deserialize signature");
-        assert_eq!(*deserialized_signature_with_status.signature(), signature);
+        assert_eq!(
+            deserialized_signature_with_status.signature().unwrap(),
+            signature
+        );
         assert!(!deserialized_signature_with_status.is_verified());
     }
 
@@ -635,11 +669,11 @@ mod tests {
     fn test_signature_with_status_serde() {
         let signature = bls12381::Signature::dummy_signature();
         let signature_with_status_1 = SignatureWithStatus {
-            signature: signature.clone(),
+            signature: WireBlsSignature::from(&signature),
             verification_status: Arc::new(AtomicBool::new(true)),
         };
         let signature_with_status_2 = SignatureWithStatus {
-            signature: signature.clone(),
+            signature: WireBlsSignature::from(&signature),
             verification_status: Arc::new(AtomicBool::new(false)),
         };
         let serialized_signature_with_status_1 =
@@ -647,11 +681,18 @@ mod tests {
         let serialized_signature_with_status_2 =
             serde_json::to_string(&signature_with_status_2).expect("Failed to serialize signature");
         assert!(serialized_signature_with_status_1 == serialized_signature_with_status_2);
+        assert_eq!(
+            serialized_signature_with_status_1,
+            serde_json::to_string(&signature).expect("Failed to serialize raw signature")
+        );
 
         let deserialized_signature_with_status: SignatureWithStatus =
             serde_json::from_str(&serialized_signature_with_status_1)
                 .expect("Failed to deserialize signature");
-        assert_eq!(*deserialized_signature_with_status.signature(), signature);
+        assert_eq!(
+            deserialized_signature_with_status.signature().unwrap(),
+            signature
+        );
         assert!(!deserialized_signature_with_status.is_verified());
     }
 
@@ -864,5 +905,51 @@ mod tests {
         assert_eq!(signature_aggregator.verified_voters().count(), 5);
         assert_eq!(signature_aggregator.all_voters().count(), 5);
         assert_eq!(validator_verifier.pessimistic_verify_set().len(), 2);
+    }
+
+    #[test]
+    fn junk_signature_with_status_decodes_without_group_element() {
+        let junk = WireBlsSignature::from_compact_array([0x7Fu8; WireBlsSignature::COMPACT_LEN]);
+        let encoded = bcs::to_bytes(&junk).unwrap();
+        let decoded: SignatureWithStatus =
+            bcs::from_bytes(&encoded).expect("length-valid payload must decode");
+        assert!(!decoded.is_verified());
+        assert!(decoded.recover_group_element().is_err());
+        assert_eq!(decoded.wire_signature(), &junk);
+    }
+
+    #[test]
+    fn junk_aggregate_payload_does_not_block_ledger_info_match() {
+        let ledger_info = LedgerInfo::new(BlockInfo::empty(), HashValue::random());
+        let dummy = bls12381::Signature::dummy_signature();
+        let valid = AggregateSignature::new(BitVec::from(vec![true]), Some(dummy.clone()));
+        let mut encoded = bcs::to_bytes(&valid).unwrap();
+
+        let dummy_bytes = bcs::to_bytes(&dummy).unwrap();
+        let junk = WireBlsSignature::from_compact_array([0xEEu8; WireBlsSignature::COMPACT_LEN]);
+        let junk_bytes = bcs::to_bytes(&junk).unwrap();
+        assert_eq!(dummy_bytes.len(), junk_bytes.len());
+        let start = encoded.len() - dummy_bytes.len();
+        encoded[start..].copy_from_slice(&junk_bytes);
+
+        let decoded: AggregateSignature =
+            bcs::from_bytes(&encoded).expect("compressed payload must decode");
+        assert!(decoded.try_group_element().is_err());
+        assert_eq!(decoded.wire_sig(), Some(&junk));
+
+        let li_with_sigs = LedgerInfoWithSignatures::new(ledger_info.clone(), decoded);
+        // Commit-vote matching compares ledger fields only; decompression
+        // must not run (and must not fail) before this equality check.
+        assert_eq!(li_with_sigs.ledger_info(), &ledger_info);
+        assert_eq!(li_with_sigs.commit_info(), ledger_info.commit_info());
+
+        let vote_placeholder = LedgerInfo::new(
+            ledger_info.commit_info().clone(),
+            ledger_info.consensus_data_hash(),
+        );
+        assert_eq!(&vote_placeholder, li_with_sigs.ledger_info());
+        assert!(li_with_sigs
+            .verify_signatures(&ValidatorVerifier::new(vec![]))
+            .is_err());
     }
 }

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -555,9 +555,28 @@ impl<T: Clone + Send + Sync + Serialize + CryptoHash> SignatureAggregator<T> {
         verifier.aggregate_signatures(recovered.iter().map(|(voter, sig)| (voter, sig)))
     }
 
-    fn filter_invalid_signatures(&mut self, verifier: &ValidatorVerifier) {
+    /// Keep only signatures that verify against `self.data`.
+    ///
+    /// `SignatureWithStatus::is_verified` records that a signature verified,
+    /// never *which* message it verified. A commit vote can therefore arrive
+    /// already marked verified after `CommitVote::verify` checked the voter's
+    /// own `LedgerInfo`. Recovery must re-check every signature here.
+    fn drop_signatures_not_bound_to_data(&mut self, verifier: &ValidatorVerifier) {
         let signatures = mem::take(&mut self.signatures);
-        self.signatures = verifier.filter_invalid_signatures(&self.data, signatures);
+        let mut retained = BTreeMap::new();
+        for (author, signature) in signatures {
+            let bound = signature
+                .recover_group_element()
+                .ok()
+                .is_some_and(|point| verifier.verify(author, &self.data, &point).is_ok());
+            if bound {
+                signature.set_verified();
+                retained.insert(author, signature);
+            } else {
+                verifier.add_pessimistic_verify_set(author);
+            }
+        }
+        self.signatures = retained;
     }
 
     /// Try to aggregate all signatures if the voting power is enough. If the aggregated signature is
@@ -566,21 +585,20 @@ impl<T: Clone + Send + Sync + Serialize + CryptoHash> SignatureAggregator<T> {
         &mut self,
         verifier: &ValidatorVerifier,
     ) -> Result<(T, AggregateSignature), VerifyError> {
-        let aggregated_sig = self.try_aggregate(verifier)?;
-
-        match verifier.verify_multi_signatures(&self.data, &aggregated_sig) {
-            Ok(_) => {
-                // We are not marking all the signatures as "verified" here, as two malicious
-                // voters can collude and create a valid aggregated signature.
-                Ok((self.data.clone(), aggregated_sig))
-            },
-            Err(_) => {
-                self.filter_invalid_signatures(verifier);
-
-                let aggregated_sig = self.try_aggregate(verifier)?;
-                Ok((self.data.clone(), aggregated_sig))
-            },
+        let first = self.try_aggregate(verifier)?;
+        if verifier.verify_multi_signatures(&self.data, &first).is_ok() {
+            // Do not mark every stored signature verified: two malicious
+            // voters can collude to form a valid aggregate that includes
+            // an unbound individual signature.
+            return Ok((self.data.clone(), first));
         }
+
+        self.drop_signatures_not_bound_to_data(verifier);
+        let recovered = self.try_aggregate(verifier)?;
+        // Fail closed: never return a certificate that does not verify
+        // against this aggregator's own data.
+        verifier.verify_multi_signatures(&self.data, &recovered)?;
+        Ok((self.data.clone(), recovered))
     }
 
     pub fn data(&self) -> &T {
@@ -951,5 +969,61 @@ mod tests {
         assert!(li_with_sigs
             .verify_signatures(&ValidatorVerifier::new(vec![]))
             .is_err());
+    }
+
+    /// A signature that is valid for a different LedgerInfo, even if already
+    /// marked verified, must be dropped on the recovery path. Remaining
+    /// honest votes over the aggregator's data must still certify.
+    #[test]
+    fn verified_signature_for_other_ledger_info_is_dropped_on_recovery() {
+        let commit_info = BlockInfo::empty();
+        let target = LedgerInfo::new(commit_info.clone(), HashValue::from_u64(1));
+        let other = LedgerInfo::new(commit_info, HashValue::from_u64(2));
+        assert_ne!(target, other);
+
+        const NUM_SIGNERS: u8 = 7;
+        let signers: Vec<ValidatorSigner> = (0..NUM_SIGNERS)
+            .map(|i| ValidatorSigner::random([i; 32]))
+            .collect();
+        let infos: Vec<ValidatorConsensusInfo> = signers
+            .iter()
+            .map(|s| ValidatorConsensusInfo::new(s.author(), s.public_key(), 1))
+            .collect();
+        let verifier = ValidatorVerifier::new_with_quorum_voting_power(infos, 5)
+            .expect("Incorrect quorum size.");
+
+        let mut aggregator = SignatureAggregator::new(target.clone());
+        let mut expected_partial = PartialSignatures::empty();
+
+        // Poison: valid over `other`, already marked verified.
+        let poison = SignatureWithStatus::from(signers[0].sign(&other).unwrap());
+        poison.set_verified();
+        aggregator.add_signature(signers[0].author(), &poison);
+
+        for signer in signers.iter().skip(1).take(5) {
+            let sig = SignatureWithStatus::from(signer.sign(&target).unwrap());
+            aggregator.add_signature(signer.author(), &sig);
+            expected_partial.add_signature(signer.author(), signer.sign(&target).unwrap());
+        }
+
+        assert_eq!(aggregator.all_voters().count(), 6);
+        let (certified_data, aggregate) = aggregator
+            .aggregate_and_verify(&verifier)
+            .expect("honest quorum must still certify after dropping the unbound signature");
+        assert_eq!(certified_data, target);
+        verifier
+            .verify_multi_signatures(&target, &aggregate)
+            .expect("returned certificate must verify against the aggregator data");
+        assert_eq!(
+            aggregate,
+            verifier
+                .aggregate_signatures(expected_partial.signatures_iter())
+                .unwrap()
+        );
+        assert_eq!(aggregator.all_voters().count(), 5);
+        assert!(verifier
+            .pessimistic_verify_set()
+            .contains(&signers[0].author()));
+        assert!(!aggregator.all_voters().any(|a| *a == signers[0].author()));
     }
 }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -55,6 +55,7 @@ pub mod validator_verifier;
 pub mod vesting;
 pub mod vm_status;
 pub mod waypoint;
+pub mod wire_bls;
 pub mod write_set;
 
 pub use account_address::AccountAddress as PeerId;

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -279,7 +279,10 @@ impl ValidatorVerifier {
         if (!self.optimistic_sig_verification || self.pessimistic_verify_set.contains(&author))
             && !signature_with_status.is_verified()
         {
-            self.verify(author, message, signature_with_status.signature())?;
+            let point = signature_with_status
+                .recover_group_element()
+                .map_err(|_| VerifyError::InvalidMultiSignature)?;
+            self.verify(author, message, &point)?;
             signature_with_status.set_verified();
         }
         Ok(())
@@ -296,10 +299,11 @@ impl ValidatorVerifier {
             .into_par_iter()
             .with_min_len(4) // At least 4 signatures are verified in each task
             .filter_map(|(account_address, signature)| {
+                let recovered = signature.recover_group_element().ok();
                 if signature.is_verified()
-                    || self
-                        .verify(account_address, message, signature.signature())
-                        .is_ok()
+                    || recovered
+                        .as_ref()
+                        .is_some_and(|point| self.verify(account_address, message, point).is_ok())
                 {
                     signature.set_verified();
                     Some((account_address, signature))
@@ -371,10 +375,11 @@ impl ValidatorVerifier {
                 return Ok(());
             }
         }
-        // Verify empty multi signature
+        // Verify empty multi signature. Decompression happens here, after the
+        // bitmask and voting-power checks above.
         let multi_sig = multi_signature
-            .sig()
-            .as_ref()
+            .try_group_element()
+            .map_err(|_| VerifyError::InvalidMultiSignature)?
             .ok_or(VerifyError::EmptySignature)?;
         // Verify the optimistically aggregated signature.
         let aggregated_key =
@@ -405,10 +410,11 @@ impl ValidatorVerifier {
         }
         // Verify the quorum voting power of the authors
         self.check_voting_power(authors.iter(), true)?;
-        // Verify empty aggregated signature
+        // Verify empty aggregated signature. Decompression happens here, after
+        // the bitmask and voting-power checks above.
         let aggregated_sig = aggregated_signature
-            .sig()
-            .as_ref()
+            .try_group_element()
+            .map_err(|_| VerifyError::InvalidMultiSignature)?
             .ok_or(VerifyError::EmptySignature)?;
 
         aggregated_sig

--- a/types/src/wire_bls.rs
+++ b/types/src/wire_bls.rs
@@ -1,0 +1,239 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Compressed BLS12-381 G2 payload used by consensus vote types.
+//!
+//! `bls12381::Signature` recovers a curve point inside `TryFrom` / serde. That
+//! recovery is a field square-root and is far more expensive than reading a
+//! `LedgerInfo`. Commit-vote matching only compares the ledger fields of a
+//! vote against a later full `LedgerInfoWithSignatures`; it must not depend on
+//! the attached signature being a valid group element.
+//!
+//! This type is the 96-byte encoding only. Serde matches the historical
+//! `Signature` newtype so BCS and JSON stay bitwise compatible. Recovering a
+//! `bls12381::Signature` is a separate, explicit step used by verification
+//! and aggregation.
+
+use aptos_crypto::{bls12381, CryptoMaterialError};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{convert::TryFrom, fmt, hash::Hash};
+
+/// AIP-80 prefix accepted on the human-readable path, matching `bls12381::Signature`.
+const BLS_SIG_AIP80_PREFIX: &str = "bls12381-sig-";
+
+/// 96-byte compressed BLS signature that has not been turned into a group element.
+#[derive(Clone, Copy)]
+pub struct WireBlsSignature {
+    compact: [u8; bls12381::Signature::LENGTH],
+}
+
+impl WireBlsSignature {
+    /// Compressed encoding length, identical to `bls12381::Signature::LENGTH`.
+    pub const COMPACT_LEN: usize = bls12381::Signature::LENGTH;
+
+    /// Wrap an already-recovered signature by re-encoding it to compressed bytes.
+    pub fn capture_point(signature: &bls12381::Signature) -> Self {
+        Self {
+            compact: signature.to_bytes(),
+        }
+    }
+
+    /// Accept a fixed-size compressed payload. No curve checks run here.
+    pub fn from_compact_array(compact: [u8; Self::COMPACT_LEN]) -> Self {
+        Self { compact }
+    }
+
+    /// Accept a slice if and only if it is the compressed encoding length.
+    pub fn from_compact_slice(bytes: &[u8]) -> Result<Self, CryptoMaterialError> {
+        let compact: [u8; Self::COMPACT_LEN] = bytes
+            .try_into()
+            .map_err(|_| CryptoMaterialError::WrongLengthError)?;
+        Ok(Self { compact })
+    }
+
+    /// Borrow the compressed encoding.
+    pub fn compact_bytes(&self) -> &[u8; Self::COMPACT_LEN] {
+        &self.compact
+    }
+
+    /// Recover the G2 element. This is the first decompression for values
+    /// that arrived on the wire.
+    pub fn recover_group_element(&self) -> Result<bls12381::Signature, CryptoMaterialError> {
+        bls12381::Signature::try_from(self.compact.as_slice())
+    }
+}
+
+impl From<bls12381::Signature> for WireBlsSignature {
+    fn from(signature: bls12381::Signature) -> Self {
+        Self::capture_point(&signature)
+    }
+}
+
+impl From<&bls12381::Signature> for WireBlsSignature {
+    fn from(signature: &bls12381::Signature) -> Self {
+        Self::capture_point(signature)
+    }
+}
+
+impl PartialEq for WireBlsSignature {
+    fn eq(&self, other: &Self) -> bool {
+        self.compact == other.compact
+    }
+}
+
+impl Eq for WireBlsSignature {}
+
+impl Hash for WireBlsSignature {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        state.write(&self.compact);
+    }
+}
+
+impl fmt::Debug for WireBlsSignature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(self.compact))
+    }
+}
+
+impl fmt::Display for WireBlsSignature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(self.compact))
+    }
+}
+
+impl Serialize for WireBlsSignature {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // Field name and encoding must stay identical to `bls12381::Signature`.
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&format!("0x{}", hex::encode(self.compact)))
+        } else {
+            serializer.serialize_newtype_struct("Signature", serde_bytes::Bytes::new(&self.compact))
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for WireBlsSignature {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        if deserializer.is_human_readable() {
+            let encoded = String::deserialize(deserializer)?;
+            decode_human_readable_compact(&encoded).map_err(D::Error::custom)
+        } else {
+            #[derive(Deserialize)]
+            #[serde(rename = "Signature")]
+            struct SignatureBytes<'a>(&'a [u8]);
+
+            let SignatureBytes(bytes) = SignatureBytes::deserialize(deserializer)?;
+            Self::from_compact_slice(bytes).map_err(D::Error::custom)
+        }
+    }
+}
+
+fn decode_human_readable_compact(encoded: &str) -> Result<WireBlsSignature, CryptoMaterialError> {
+    let mut body = encoded
+        .strip_prefix(BLS_SIG_AIP80_PREFIX)
+        .unwrap_or(encoded);
+    body = body.strip_prefix("0x").unwrap_or(body);
+    let raw = hex::decode(body).map_err(|_| CryptoMaterialError::DeserializationError)?;
+    WireBlsSignature::from_compact_slice(&raw)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aptos_crypto::{bls12381::Signature, ValidCryptoMaterial, ValidCryptoMaterialStringExt};
+
+    fn valid_point() -> Signature {
+        Signature::dummy_signature()
+    }
+
+    #[test]
+    fn compact_round_trip_matches_signature_bytes() {
+        let point = valid_point();
+        let wire = WireBlsSignature::capture_point(&point);
+        assert_eq!(wire.compact_bytes().as_slice(), point.to_bytes().as_slice());
+        assert_eq!(wire.recover_group_element().unwrap(), point);
+        assert_eq!(
+            ValidCryptoMaterial::to_bytes(&point).len(),
+            WireBlsSignature::COMPACT_LEN
+        );
+    }
+
+    #[test]
+    fn bcs_matches_bls_signature_newtype() {
+        let point = valid_point();
+        let wire = WireBlsSignature::from(&point);
+        assert_eq!(
+            bcs::to_bytes(&wire).unwrap(),
+            bcs::to_bytes(&point).unwrap()
+        );
+    }
+
+    #[test]
+    fn json_matches_bls_signature_string() {
+        let point = valid_point();
+        let wire = WireBlsSignature::from(&point);
+        assert_eq!(
+            serde_json::to_string(&wire).unwrap(),
+            serde_json::to_string(&point).unwrap()
+        );
+        assert_eq!(
+            serde_json::to_string(&wire).unwrap(),
+            serde_json::to_string(&point.to_encoded_string().unwrap()).unwrap()
+        );
+    }
+
+    #[test]
+    fn option_wrapper_stays_bitwise_compatible() {
+        let point = valid_point();
+        let old: Option<Signature> = Some(point.clone());
+        let new: Option<WireBlsSignature> = Some(WireBlsSignature::from(&point));
+        assert_eq!(bcs::to_bytes(&old).unwrap(), bcs::to_bytes(&new).unwrap());
+        assert_eq!(
+            serde_json::to_string(&old).unwrap(),
+            serde_json::to_string(&new).unwrap()
+        );
+    }
+
+    #[test]
+    fn well_formed_length_junk_decodes_and_fails_only_on_recover() {
+        let junk = [0xFFu8; WireBlsSignature::COMPACT_LEN];
+        let wire = WireBlsSignature::from_compact_array(junk);
+        let encoded = bcs::to_bytes(&wire).unwrap();
+        let decoded: WireBlsSignature = bcs::from_bytes(&encoded).unwrap();
+        assert_eq!(decoded, wire);
+        assert!(decoded.recover_group_element().is_err());
+
+        let json = serde_json::to_string(&wire).unwrap();
+        let from_json: WireBlsSignature = serde_json::from_str(&json).unwrap();
+        assert_eq!(from_json, wire);
+        assert!(from_json.recover_group_element().is_err());
+    }
+
+    #[test]
+    fn wrong_length_is_rejected_before_recover() {
+        assert!(WireBlsSignature::from_compact_slice(&[0u8; 32]).is_err());
+        let short = serde_bytes::Bytes::new(&[0u8; 8]);
+        // Direct slice helper is the length gate used by serde.
+        assert_eq!(
+            WireBlsSignature::from_compact_slice(short.as_ref()).unwrap_err(),
+            CryptoMaterialError::WrongLengthError
+        );
+    }
+
+    #[test]
+    fn human_readable_accepts_aip80_prefix_without_recovering() {
+        let junk = [0xAAu8; WireBlsSignature::COMPACT_LEN];
+        let encoded = format!("{}0x{}", BLS_SIG_AIP80_PREFIX, hex::encode(junk));
+        let wire = decode_human_readable_compact(&encoded).unwrap();
+        assert_eq!(wire.compact_bytes(), &junk);
+        assert!(wire.recover_group_element().is_err());
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

**Depends on / should land after #427** (clean-room deferred BLS decompression). This branch is stacked on `cursor/defer-bls-decompression-1a4b`. Full-`LedgerInfo` matching needs that deferred-signature shape so a well-formed but invalid payload can still be compared as ledger fields without G2 recovery.

Clean-room rewrite on this tree (not a cherry-pick, patch, or mechanical port from `aptos-labs/aptos-core`). Upstream intent was read only to identify the bug and the invariant (`aptos-labs/aptos-core#20335`): a BLS commit vote is valid only for the exact `LedgerInfo` it signed (`commit_info` **plus** `consensus_data_hash`).

**Bug:** `BufferItem::add_signature_if_matched` admitted a `CommitVote` into the partial proof when only `commit_info` matched. A vote signed over a different `consensus_data_hash` — a valid signature over a *different* message — could still aggregate. `CommitVote::verify` checks the vote against its own `ledger_info` and may set `SignatureWithStatus::is_verified`, which does not record *which* message was verified.

**Invariant:**
- Adding a commit vote to an Executed or Signed partial proof requires the vote's entire `LedgerInfo` to equal the aggregator's data. Mismatch fails closed; the signature is not inserted.
- The Ordered path still stores at most one vote per author after an ordered-only `commit_info` compare; `create_signature_aggregator` later admits only full-`LedgerInfo` matches (unchanged).
- Aggregation recovery re-checks every stored signature against the aggregator's own data and does not treat a cached `is_verified` flag as proof of that binding. Unbound authors go to the pessimistic verify set.
- A recovered certificate is verified against the aggregator's data before it is returned. Quorum voting-power checks are unchanged.
- No `unsafe`. Consensus-facing maps stay `BTreeMap`.

## How Has This Been Tested?

- `reject_vote_with_unrelated_consensus_data_hash_and_still_quorum` (`consensus/src/pipeline/buffer_item.rs`) — a vote whose `consensus_data_hash` differs is rejected on both Executed and Signed items even though `CommitVote::verify` succeeds; an honest quorum still produces a certificate that passes `verify_signatures`.
- `signs_same_ledger_info_requires_consensus_data_hash` (`consensus/consensus-types/src/pipeline/commit_vote.rs`) — helper requires both `commit_info` and `consensus_data_hash`.
- `verified_signature_for_other_ledger_info_is_dropped_on_recovery` (`types/src/ledger_info.rs`) — a signature valid over a different `LedgerInfo`, already marked verified, is dropped on recovery; the remaining honest quorum still certifies.
- `cargo test -p aptos-consensus-types` — **20 passed** (includes the new helper test).
- `cargo test -p aptos-types` — **222 passed / 3 ignored** (includes the new recovery test and existing `test_signature_aggregator`).
- `cargo test -p aptos-consensus --lib` — **319 passed / 6 ignored** (includes the new mismatch/quorum test plus existing `buffer_item` happy/bad paths).

Aikido SAST was attempted on the new/modified files. The Aikido MCP is not authenticated in this environment (`aikido_full_scan` requires a browser sign-in), so the scan could not complete here.

## Key Areas to Review

- `admit_into_partial_commit_proof` — fail-closed full-`LedgerInfo` gate before `add_signature`.
- `SignatureAggregator::aggregate_and_verify` recovery — always re-verify individuals against `self.data`, then verify the recovered aggregate.
- Confirm Ordered-path behavior is unchanged (unverified cache + later full match).

## Type of Change

- [x] Bug fix
- [x] Tests

## Which Components or Systems Does This Change Impact?

- [x] Validator Node
- [x] Other (specify): `aptos-consensus`, `aptos-consensus-types`, `aptos-types` commit-vote aggregation

## Checklist

- [x] Clean-room implementation; no aptos-labs commit SHAs, patches, or copied function bodies
- [x] Depends on #427; should land after it
- [x] `RUST_SECURE_CODING.md` followed: no `unsafe`, `BTreeMap` for consensus maps, `Result` / fail-closed on mismatch
- [x] Named crate tests for changed crates

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6aed5e3f-ea91-4996-a440-dbdd426760b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6aed5e3f-ea91-4996-a440-dbdd426760b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/movement-network/codesmith/aptos-core/pr/429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791264266&installation_model_id=17568&pr_number=429&repository=movement-network%2Faptos-core&return_to=https%3A%2F%2Fgithub.com%2Fmovement-network%2Faptos-core%2Fpull%2F429&signature=8d511914779efe0ae48bf29ae63807a47876f9979d42a529ed813073f4ac826e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->